### PR TITLE
fix: allow columns with multiple size classes + fix content block size

### DIFF
--- a/src/components/ContentBlocks/BlockVideoTitleTextButton/BlockVideoTitleTextButton.test.tsx
+++ b/src/components/ContentBlocks/BlockVideoTitleTextButton/BlockVideoTitleTextButton.test.tsx
@@ -62,8 +62,8 @@ describe('<BlockVideoTitleTextButton />', () => {
 		expect(containerElement.hasClass('o-container')).toEqual(true);
 		expect(spacerElement.hasClass('u-spacer')).toEqual(true);
 		expect(gridElement.hasClass('o-grid')).toEqual(true);
-		expect(leftColumnElement.hasClass('o-grid-col-6')).toEqual(true);
-		expect(rightColumnElement.hasClass('o-grid-col-6')).toEqual(true);
+		expect(leftColumnElement.hasClass('o-grid-col-bp2-6')).toEqual(true);
+		expect(rightColumnElement.hasClass('o-grid-col-bp2-6')).toEqual(true);
 		expect(contentElement.hasClass('c-content')).toEqual(true);
 	});
 

--- a/src/components/ContentBlocks/BlockVideoTitleTextButton/BlockVideoTitleTextButton.tsx
+++ b/src/components/ContentBlocks/BlockVideoTitleTextButton/BlockVideoTitleTextButton.tsx
@@ -27,14 +27,14 @@ export const BlockVideoTitleTextButton: FunctionComponent<BlockVideoTitleTextBut
 		<Container mode="horizontal">
 			<Spacer>
 				<Grid>
-					<Column size="6">
+					<Column size="2-6">
 						{/* 16 by 9 => 100% by 56% */}
 						<div className="c-video-wrapper" style={{ paddingBottom: '56%' }}>
 							{/* TODO replace this with the flowplayer video component */}
 							<video src={videoSource} />
 						</div>
 					</Column>
-					<Column size="6">
+					<Column size="2-6">
 						<div className="c-content">
 							{title && <h2>{title}</h2>}
 							{text && <p dangerouslySetInnerHTML={{ __html: marked(text) }} />}

--- a/src/components/Grid/Column.test.tsx
+++ b/src/components/Grid/Column.test.tsx
@@ -22,6 +22,18 @@ describe('<Column />', () => {
 		expect(columnComponent3.hasClass(`o-grid-col-bp${size3}`)).toEqual(true);
 	});
 
+	it('Should correctly set multiple sizing clasnames', () => {
+		const size1 = '12';
+		const size2 = '1-4';
+		const size3 = '2-11';
+
+		const columnComponent = shallow(<Column size={[size1, size2, size3]}>Hello!</Column>);
+
+		expect(columnComponent.hasClass(`o-grid-col-${size1}`)).toEqual(true);
+		expect(columnComponent.hasClass(`o-grid-col-bp${size2}`)).toEqual(true);
+		expect(columnComponent.hasClass(`o-grid-col-bp${size3}`)).toEqual(true);
+	});
+
 	it('Should correctly pass children', () => {
 		const columnComponent = shallow(
 			<Column size="12">

--- a/src/components/Grid/Column.tsx
+++ b/src/components/Grid/Column.tsx
@@ -1,62 +1,74 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 
+type GridSize =
+	| '1'
+	| '2'
+	| '3'
+	| '4'
+	| '5'
+	| '6'
+	| '7'
+	| '8'
+	| '9'
+	| '10'
+	| '11'
+	| '12'
+	| '1-1'
+	| '1-2'
+	| '1-3'
+	| '1-4'
+	| '1-5'
+	| '1-6'
+	| '1-7'
+	| '1-8'
+	| '1-9'
+	| '1-10'
+	| '1-11'
+	| '1-12'
+	| '2-1'
+	| '2-2'
+	| '2-3'
+	| '2-4'
+	| '2-5'
+	| '2-6'
+	| '2-7'
+	| '2-8'
+	| '2-9'
+	| '2-10'
+	| '2-11'
+	| '2-12'
+	| '3-1'
+	| '3-2'
+	| '3-3'
+	| '3-4'
+	| '3-5'
+	| '3-6'
+	| '3-7'
+	| '3-8'
+	| '3-9'
+	| '3-10'
+	| '3-11'
+	| '3-12'
+	| 'static'
+	| 'flex';
+
 export interface ColumnProps {
-	size:
-		| '1'
-		| '2'
-		| '3'
-		| '4'
-		| '5'
-		| '6'
-		| '7'
-		| '8'
-		| '9'
-		| '10'
-		| '11'
-		| '12'
-		| '1-1'
-		| '1-2'
-		| '1-3'
-		| '1-4'
-		| '1-5'
-		| '1-6'
-		| '1-7'
-		| '1-8'
-		| '1-9'
-		| '1-10'
-		| '1-11'
-		| '1-12'
-		| '2-1'
-		| '2-2'
-		| '2-3'
-		| '2-4'
-		| '2-5'
-		| '2-6'
-		| '2-7'
-		| '2-8'
-		| '2-9'
-		| '2-10'
-		| '2-11'
-		| '2-12'
-		| '3-1'
-		| '3-2'
-		| '3-3'
-		| '3-4'
-		| '3-5'
-		| '3-6'
-		| '3-7'
-		| '3-8'
-		| '3-9'
-		| '3-10'
-		| '3-11'
-		| '3-12'
-		| 'static'
-		| 'flex';
+	size: GridSize[] | GridSize;
 	children: ReactNode;
 }
 
 export const Column: FunctionComponent<ColumnProps> = ({ size, children }: ColumnProps) => {
-	const prefix = size.includes('-') ? 'bp' : '';
+	const getGridSizeColumn = (size: GridSize): string => {
+		const prefix = size.includes('-') ? 'bp' : '';
 
-	return <div className={`o-grid-col-${prefix}${size}`}>{children}</div>;
+		return `o-grid-col-${prefix}${size}`;
+	};
+	let sizes: GridSize[];
+	if (typeof size === 'string') {
+		sizes = [size];
+	} else {
+		sizes = size;
+	}
+
+	return <div className={sizes.map(getGridSizeColumn).join(' ')}>{children}</div>;
 };

--- a/src/components/Grid/Column.tsx
+++ b/src/components/Grid/Column.tsx
@@ -63,12 +63,8 @@ export const Column: FunctionComponent<ColumnProps> = ({ size, children }: Colum
 
 		return `o-grid-col-${prefix}${size}`;
 	};
-	let sizes: GridSize[];
-	if (typeof size === 'string') {
-		sizes = [size];
-	} else {
-		sizes = size;
-	}
+
+	const sizes = typeof size === 'string' ? [size] : size;
 
 	return <div className={sizes.map(getGridSizeColumn).join(' ')}>{children}</div>;
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/60710069-245fda00-9f12-11e9-8476-1fc676ba5653.png)


grid column widths work as follows:
* size 1 to 12 => are applied across all media queries
* size bp2-1 - bp1-12 => are applied on devices larger than 300px
* size bp2-1 - bp2-12 => are applied on devices larger than 600px
* size bp3-1 - bp3-12 => are applied on devices larger than 900px

if a device is encountered that is smaller than those indicated widths, the column will default to 100% wide

for the purpose of this pr i didn't have to change the column component to accept multiple sizes, but it might be useful in the future if we want to show for instance: 6 columns on desktop, 3 on tablet and 2 on mobile
The column still accepts a single size as it used it, so nothing will break.
