### PR TITLE
fix: make image grid border more pronounces + don't change image size

### DIFF
--- a/src/components/ImageGrid/ImageGrid.scss
+++ b/src/components/ImageGrid/ImageGrid.scss
@@ -4,9 +4,7 @@
 		.c-image-grid__item {
 			&.c-image-grid__item-selected,
 			&:hover {
-				border: 0.5rem solid #3FB1D6;
-				margin: 0.5rem;
-				box-sizing: content-box;
+				outline: 0.5rem solid #3FB1D6;
 			}
 		}
 	}

--- a/src/components/ImageGrid/ImageGrid.scss
+++ b/src/components/ImageGrid/ImageGrid.scss
@@ -4,7 +4,9 @@
 		.c-image-grid__item {
 			&.c-image-grid__item-selected,
 			&:hover {
-				border: 3px solid #3FB1D6;
+				border: 0.5rem solid #3FB1D6;
+				margin: 0.5rem;
+				box-sizing: content-box;
 			}
 		}
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/64705659-97f10b00-d4b0-11e9-8fd6-28da3fe7ea83.png)
![image](https://user-images.githubusercontent.com/1710840/64705662-9889a180-d4b0-11e9-81dd-337b722aff08.png)
