### PR TITLE
fix: ensure null text in blocks doesn't crash using helper method

### DIFF
--- a/src/components/ContentBlocks/BlockImageTitleTextButton/BlockImageTitleTextButton.tsx
+++ b/src/components/ContentBlocks/BlockImageTitleTextButton/BlockImageTitleTextButton.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react';
 
 import classnames from 'classnames';
-import marked from 'marked';
 
+import { convertToHtml } from '../../../helpers/convertToHtml';
 import { DefaultProps } from '../../../types';
 import { Button } from '../../Button/Button';
 import { Container } from '../../Container/Container';
@@ -39,7 +39,7 @@ export const BlockImageTitleTextButton: FunctionComponent<BlockImageTitleTextBut
 					<Column size="2-8">
 						<div className="c-content">
 							{title && <h2>{title}</h2>}
-							{text && <p dangerouslySetInnerHTML={{ __html: marked(text) }} />}
+							{text && <p dangerouslySetInnerHTML={{ __html: convertToHtml(text) }} />}
 							{buttonLabel && (
 								<Spacer margin="top">
 									<Button

--- a/src/components/ContentBlocks/BlockIntro/BlockIntro.tsx
+++ b/src/components/ContentBlocks/BlockIntro/BlockIntro.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react';
 
 import classnames from 'classnames';
-import marked from 'marked';
 
+import { convertToHtml } from '../../../helpers/convertToHtml';
 import { DefaultProps } from '../../../types';
 import { Container } from '../../Container/Container';
 
@@ -27,7 +27,7 @@ export const BlockIntro: FunctionComponent<BlockIntroProps> = ({
 				{subtitle && <h3>{subtitle}</h3>}
 				<p
 					className="o-container-vertical-intro__intro"
-					dangerouslySetInnerHTML={{ __html: marked(text) }}
+					dangerouslySetInnerHTML={{ __html: convertToHtml(text) }}
 				/>
 			</div>
 		</Container>

--- a/src/components/ContentBlocks/BlockText/BlockText.tsx
+++ b/src/components/ContentBlocks/BlockText/BlockText.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react';
 
 import classnames from 'classnames';
-import marked from 'marked';
 
+import { convertToHtml } from '../../../helpers/convertToHtml';
 import { DefaultProps } from '../../../types';
 import { Container } from '../../Container/Container';
 
@@ -17,7 +17,7 @@ export const BlockText: FunctionComponent<BlockTextProps> = ({
 	<div className={classnames(className, 'o-container-vertical', 'o-container-vertical-rich-text')}>
 		<Container mode="horizontal" size="small">
 			{/* TODO escape markdown in backend */}
-			<div className="c-content" dangerouslySetInnerHTML={{ __html: marked(text) }} />
+			<div className="c-content" dangerouslySetInnerHTML={{ __html: convertToHtml(text) }} />
 		</Container>
 	</div>
 );

--- a/src/components/ContentBlocks/BlockTitleImageText/BlockTitleImageText.tsx
+++ b/src/components/ContentBlocks/BlockTitleImageText/BlockTitleImageText.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 
-import marked from 'marked';
-
+import { convertToHtml } from '../../../helpers/convertToHtml';
 import { DefaultProps } from '../../../types';
 import { Container } from '../../Container/Container';
 import { Image } from '../../Image/Image';
@@ -28,7 +27,7 @@ export const BlockTitleImageText: FunctionComponent<BlockTitleImageTextProps> = 
 				{imageSource && <Image src={imageSource} alt={imageDescription} wide={true} />}
 				{text && (
 					<Spacer margin="top">
-						<p dangerouslySetInnerHTML={{ __html: marked(text) }} />
+						<p dangerouslySetInnerHTML={{ __html: convertToHtml(text) }} />
 					</Spacer>
 				)}
 			</Container>

--- a/src/components/ContentBlocks/BlockVideoTitleTextButton/BlockVideoTitleTextButton.tsx
+++ b/src/components/ContentBlocks/BlockVideoTitleTextButton/BlockVideoTitleTextButton.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 
-import marked from 'marked';
-
+import { convertToHtml } from '../../../helpers/convertToHtml';
 import { DefaultProps } from '../../../types';
 import { Container } from '../../Container/Container';
 import { ExpandableContainer } from '../../ExpandableContainer/ExpandableContainer';
@@ -46,7 +45,7 @@ export const BlockVideoTitleTextButton: FunctionComponent<BlockVideoTitleTextBut
 										</a>
 									</h2>
 								)}
-								{text && <p dangerouslySetInnerHTML={{ __html: marked(text) }} />}
+								{text && <p dangerouslySetInnerHTML={{ __html: convertToHtml(text) }} />}
 							</ExpandableContainer>
 						</div>
 					</Column>

--- a/src/helpers/convertToHtml.ts
+++ b/src/helpers/convertToHtml.ts
@@ -1,0 +1,5 @@
+import marked from 'marked';
+
+export function convertToHtml(text: string | undefined | null) {
+	return marked(text || '');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,12 +105,14 @@ import { ToolbarTitle } from './components/Toolbar/ToolbarTitle';
 import { Tooltip } from './components/Tooltip/Tooltip';
 import { TooltipContent, TooltipTrigger } from './components/Tooltip/Tooltip.slots';
 import { WYSIWYG } from './components/WYSIWYG/WYSIWYG';
+import { convertToHtml } from './helpers/convertToHtml';
 import { useSlot } from './hooks/useSlot';
 
 export {
 	COLORS,
 	useKeyPress,
 	useSlot,
+	convertToHtml,
 	Alert,
 	Avatar,
 	AvatarIcon,


### PR DESCRIPTION
Since everything returned from the graphql is by default null
and null doesn't get the default '' from the props default, this only happens for undefined.