### PR TITLE
fix: allow multirange draghandles to overlap

### DIFF
--- a/src/components/MultiRange/MultiRange.stories.tsx
+++ b/src/components/MultiRange/MultiRange.stories.tsx
@@ -36,6 +36,11 @@ storiesOf('MultiRange', module)
 			<MultiRange disabled />
 		</MultiRangeStoryComponent>
 	))
+	.add('MultiRange allow overlap', () => (
+		<MultiRangeStoryComponent>
+			<MultiRange allowOverlap={true} onChange={action('Value changed')} />
+		</MultiRangeStoryComponent>
+	))
 	.add('MultiRange with default values', () => (
 		<MultiRangeStoryComponent defaultValues={[20, 60]}>
 			<MultiRange />

--- a/src/components/MultiRange/MultiRange.tsx
+++ b/src/components/MultiRange/MultiRange.tsx
@@ -13,6 +13,7 @@ export interface MultiRangeProps extends DefaultProps {
 	step?: number;
 	min?: number;
 	max?: number;
+	allowOverlap?: boolean;
 	onChange?: (values: number[]) => void;
 }
 
@@ -24,16 +25,20 @@ export const MultiRange: FunctionComponent<MultiRangeProps> = ({
 	step = 0.1,
 	min = 0,
 	max = 100,
+	allowOverlap = false,
 	onChange = () => {},
 }) => {
 	const classes = classnames('c-input-range', className, { 'c-input-range__disabled': disabled });
 
+	const sortedValues = [...values];
+	sortedValues.sort((a: number, b: number) => a - b);
 	return (
 		<div id={id} className={classes}>
 			<Range
 				step={step}
 				min={min}
 				max={max}
+				allowOverlap={allowOverlap}
 				values={values}
 				onChange={onChange}
 				renderTrack={({ props, children }) => (
@@ -54,9 +59,9 @@ export const MultiRange: FunctionComponent<MultiRangeProps> = ({
 								width: '100%',
 								borderRadius: '4px',
 								background: getTrackBackground({
-									values,
 									min,
 									max,
+									values: sortedValues,
 									colors:
 										values.length === 1
 											? ['hsl(190, 80%, 40%)', 'rgb(196, 196, 196)']


### PR DESCRIPTION
![](https://media.giphy.com/media/lPFfX1ak9w1PWlDyub/giphy.gif)

Important note: values received in the onChange handler are not sorted, and should be sorted by the user of the multi range.
If we try to auto sort these values the user loses their grip on the drag handle when passing an other draghandle