### PR TITLE
fix: avoid empty icon name crash, render slash instead

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -13,7 +13,7 @@ export interface IconProps extends DefaultProps {
 }
 
 export const Icon: FunctionComponent<IconProps> = ({ className, name, size, type, active }) => {
-	let IconToRender = (Icons as any)[toPascalCase(name)];
+	let IconToRender = (Icons as any)[toPascalCase(name || 'slash')];
 
 	function getIconName() {
 		const base = 'o-svg-icon';

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -6,14 +6,20 @@ import { DefaultProps } from '../../types';
 import * as Icons from '../Icons';
 
 export interface IconProps extends DefaultProps {
-	name: string;
+	name?: string;
 	size?: 'small' | 'large' | 'huge';
 	type?: 'arrows' | 'custom' | 'multicolor' | 'social' | 'wysiwyg';
 	active?: boolean;
 }
 
-export const Icon: FunctionComponent<IconProps> = ({ className, name, size, type, active }) => {
-	let IconToRender = (Icons as any)[toPascalCase(name || 'slash')];
+export const Icon: FunctionComponent<IconProps> = ({
+	className,
+	name = 'slash',
+	size,
+	type,
+	active,
+}) => {
+	let IconToRender = (Icons as any)[toPascalCase(name)];
 
 	function getIconName() {
 		const base = 'o-svg-icon';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/65133618-35919080-da03-11e9-9e31-7c9b5e8895f3.png)
