### PR TITLE
feat(alert): add html support for alerts

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -41,7 +41,6 @@ storiesOf('Alert', module)
 	.add('Alerts html multi line', () => (
 		<Alert
 			message={'Info alert message<br/>Info alert message<br/>Info alert message'}
-			dark={true}
 			onClose={action('alert closed')}
 		/>
 	))

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -38,6 +38,13 @@ storiesOf('Alert', module)
 			</div>
 		</React.Fragment>
 	))
+	.add('Alerts html multi line', () => (
+		<Alert
+			message={'Info alert message<br/>Info alert message<br/>Info alert message'}
+			dark={true}
+			onClose={action('alert closed')}
+		/>
+	))
 	.add('Alerts custom content', () => (
 		<React.Fragment>
 			<Alert>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -43,7 +43,8 @@ export const Alert: FunctionComponent<AlertProps> = ({
 						<Spinner light={dark} />
 					)}
 				</Spacer>
-				{message || children}
+				{!!message && <span dangerouslySetInnerHTML={{ __html: message.toString() }} />}
+				{!!children && children}
 			</div>
 			{!!onClose && (
 				<Button


### PR DESCRIPTION
So we can do multiline error messages without needing  custom content
We can use this for showing multiple validation errors for the collection edit screen and the collection publish modal

![image](https://user-images.githubusercontent.com/1710840/66582224-b0bd1100-eb81-11e9-8404-6f7d236e1859.png)
