### PR TITLE
fix(wysiwyg): force list styles for ul and ol

### DIFF
--- a/src/components/WYSIWYG/WYSIWYG.scss
+++ b/src/components/WYSIWYG/WYSIWYG.scss
@@ -4,9 +4,23 @@
 	background: #D6DEE3;
 }
 
-.trumbowyg-editor strong {
-	// Fixes strange bug in Chrome where the wysiwyg wouldn't clear bold styling
-	font-weight: 600;
+.trumbowyg-editor {
+	strong {
+		// Fixes strange bug in Chrome where the wysiwyg wouldn't clear bold styling
+		font-weight: 600;
+	}
+
+	ol, ul {
+		padding-left: 20px;
+	}
+
+	ul {
+		list-style: disc;
+	}
+
+	ol {
+		list-style: decimal;
+	}
 }
 
 .c-content table td {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/67700951-498bc300-f9af-11e9-994c-89dadc1d2bea.png)

https://district01.atlassian.net/browse/AVO2-743