### PR TITLE
fix(wysiwyg): trumbowyg instance never being destroyed

### DIFF
--- a/src/components/WYSIWYG/WYSIWYG.tsx
+++ b/src/components/WYSIWYG/WYSIWYG.tsx
@@ -77,6 +77,12 @@ export class WYSIWYG extends React.Component<WYSIWYGProps> {
 		this.reInitEditor(this.props);
 	}
 
+	componentWillUnmount() {
+		if (this.editor) {
+			this.editor.trumbowyg('destroy');
+		}
+	}
+
 	// Switched to class based component so we can use this lifecycle hook inside the component
 	// so we can check the value of the Trumbowyg editor
 	// to see if the sate is equal to the externally received props.data value


### PR DESCRIPTION
This caused issues with trumbowyg applying dom updates which didn't play well with React.