### PR TITLE
fix(tag-list): avoid stretched close buttons

### DIFF
--- a/src/components/TagList/TagList.scss
+++ b/src/components/TagList/TagList.scss
@@ -49,7 +49,6 @@
 	background: $color-gray-200;
 	color: #FFF;
 	text-align: center;
-	flex: 1 1 100%;
 	border: none;
 	width: 1.8rem;
 	height: 1.8rem;

--- a/src/components/TagList/TagList.stories.tsx
+++ b/src/components/TagList/TagList.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '../../helpers';
 
 import { TagList } from './TagList';
+import { loremIpsum } from 'lorem-ipsum';
 
 const tags = [
 	{ label: 'Aluminium', id: 'aluminium' },
@@ -69,6 +70,11 @@ storiesOf('components/TagList', module)
 			onTagClosed={action('Tag closed')}
 			onTagClicked={action('Tag clicked')}
 		/>
+	))
+	.add('TagList with multiline tags', () => (
+		<div style={{ width: '300px' }}>
+			<TagList tags={[{ label: loremIpsum({ count: 1 }), id: 'test' }]} closable swatches={false} />
+		</div>
 	))
 	.add('TagList with selectable tags', () => (
 		<TagListStoryComponent>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1710840/75439257-c331be80-5959-11ea-9185-7da9728a8f92.png)

after:
![image](https://user-images.githubusercontent.com/1710840/75439266-c5941880-5959-11ea-9063-902688a08e23.png)
