### PR TITLE
feat(table): add onTableClick option

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,7 +42,6 @@ const Button: FunctionComponent<ButtonProps> = ({
 	type = 'primary',
 }) => {
 	const handleButtonClick = (evt: MouseEvent<HTMLElement>) => {
-		evt.stopPropagation();
 		if (!disabled && onClick) {
 			onClick(evt);
 		}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -40,31 +40,40 @@ const Button: FunctionComponent<ButtonProps> = ({
 	size,
 	title,
 	type = 'primary',
-}) => (
-	<button
-		className={classnames(className, 'c-button', {
-			'c-button--active': active,
-			'c-button--auto': autoHeight,
-			'c-button--small': size === 'small',
-			'c-button--block': block,
-			'c-button--icon': icon && !label,
-			[`c-button--${type}`]: type,
-		})}
-		onClick={disabled ? () => {} : onClick}
-		disabled={disabled}
-		aria-label={ariaLabel}
-		title={title}
-	>
-		{children ? (
-			children
-		) : (
-			<div className="c-button__content">
-				{icon && <Icon className="c-button__icon" name={icon} active={active} />}
-				{label && <div className="c-button__label">{label}</div>}
-				{arrow && <Icon className="c-button__icon" name="caret-down" />}
-			</div>
-		)}
-	</button>
-);
+}) => {
+	const handleButtonClick = (evt: MouseEvent<HTMLElement>) => {
+		evt.stopPropagation();
+		if (!disabled && onClick) {
+			onClick(evt);
+		}
+	};
+
+	return (
+		<button
+			className={classnames(className, 'c-button', {
+				'c-button--active': active,
+				'c-button--auto': autoHeight,
+				'c-button--small': size === 'small',
+				'c-button--block': block,
+				'c-button--icon': icon && !label,
+				[`c-button--${type}`]: type,
+			})}
+			onClick={handleButtonClick}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			title={title}
+		>
+			{children ? (
+				children
+			) : (
+				<div className="c-button__content">
+					{icon && <Icon className="c-button__icon" name={icon} active={active} />}
+					{label && <div className="c-button__label">{label}</div>}
+					{arrow && <Icon className="c-button__icon" name="caret-down" />}
+				</div>
+			)}
+		</button>
+	);
+};
 
 export { Button };

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -33,6 +33,23 @@ $c-table-row-selected-bg: $color-primary !default;
 	th {
 		font-weight: 500;
 	}
+
+	tr {
+		line-height: 32px;
+	}
+
+	tr {
+		> td,
+		> th {
+			&:first-child {
+				padding-left: 5px;
+			}
+		}
+	}
+
+	tr.u-clickable:hover {
+		background-color: $color-gray-50;
+	}
 }
 
 .c-table--styled {

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -26,8 +26,8 @@ $c-table-row-selected-bg: $color-primary !default;
 	td {
 		text-align: left;
 		padding: 0.8rem 0;
-		vertical-align: top;
 		position: relative;
+		vertical-align: middle;
 	}
 
 	th {
@@ -35,14 +35,13 @@ $c-table-row-selected-bg: $color-primary !default;
 	}
 
 	tr {
-		line-height: 32px;
-	}
-
-	tr {
 		> td,
 		> th {
 			&:first-child {
 				padding-left: 5px;
+			}
+			&:last-child {
+				padding-right: 5px;
 			}
 		}
 	}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -134,4 +134,15 @@ storiesOf('components/Table', module)
 				emptyStateMessage="No data was found. Try again later."
 			/>
 		</TableStoryComponent>
+	))
+	.add('Table clickable row', () => (
+		<TableStoryComponent>
+			<Table
+				columns={COLUMNS}
+				data={DATA}
+				rowKey="id"
+				renderCell={(row, cell) => renderCell(row, cell)}
+				onRowClick={action('Row clicked')}
+			/>
+		</TableStoryComponent>
 	));

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -67,6 +67,12 @@ export const Table: FunctionComponent<TableProps> = ({
 	untable,
 	variant,
 }) => {
+	const handleRowClick = (rowData: any) => {
+		if (onRowClick) {
+			onRowClick(rowData);
+		}
+	};
+
 	const renderHeading = (heading: TableColumn) => {
 		const { id, col, sortable, label } = heading;
 
@@ -130,7 +136,7 @@ export const Table: FunctionComponent<TableProps> = ({
 									<tr
 										key={`table-row-${rowData[rowKey]}`}
 										className={onRowClick ? 'u-clickable' : ''}
-										onClick={() => (onRowClick ? onRowClick(rowData) : () => {})}
+										onClick={() => handleRowClick(rowData)}
 									>
 										{columns
 											.map(col => col.id)

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -38,6 +38,7 @@ export interface TableProps extends DefaultProps {
 	horizontal?: boolean;
 	nowrap?: boolean;
 	onColumnClick?: (id: string) => void;
+	onRowClick?: (rowData: any) => void;
 	renderCell?: (rowData: any, columnId: string, rowIndex: number, columnIndex: number) => ReactNode;
 	rowKey?: string;
 	sortColumn?: string;
@@ -57,6 +58,7 @@ export const Table: FunctionComponent<TableProps> = ({
 	horizontal,
 	nowrap,
 	onColumnClick = () => {},
+	onRowClick,
 	renderCell = () => null,
 	rowKey,
 	sortColumn,
@@ -125,7 +127,11 @@ export const Table: FunctionComponent<TableProps> = ({
 						{data.length > 0 && rowKey && (
 							<tbody>
 								{data.map((rowData, rowIndex) => (
-									<tr key={`table-row-${rowData[rowKey]}`}>
+									<tr
+										key={`table-row-${rowData[rowKey]}`}
+										className={onRowClick ? 'u-clickable' : ''}
+										onClick={() => (onRowClick ? onRowClick(rowData) : () => {})}
+									>
 										{columns
 											.map(col => col.id)
 											.map((columnId, columnIndex) => (


### PR DESCRIPTION
useful for when there are no multiple actions on a row, just one action to go to the detail of the clicked row item

![image](https://user-images.githubusercontent.com/1710840/75767657-74ae6680-5d43-11ea-9b5a-537b5d9c15e8.png)
