### PR TITLE
fix(block-projects-spotlight): set navigate prop on each element

### DIFF
--- a/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.mock.tsx
+++ b/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.mock.tsx
@@ -1,3 +1,4 @@
+import { action } from '../../helpers';
 import { ButtonAction } from '../../types';
 
 import { ImageInfo } from './BlockProjectsSpotlight';
@@ -12,15 +13,18 @@ export const MOCK_SPOTLIGHT_PROJECTS: ImageInfo[] = [
 		image: '/images/500x200.svg',
 		title: 'My project',
 		buttonAction: MOCK_BUTTON_ACTION,
+		navigate: action('Clicked on My project'),
 	},
 	{
 		image: '/images/500x200.svg',
 		title: 'My project 2',
 		buttonAction: MOCK_BUTTON_ACTION,
+		navigate: action('Clicked on My project 2'),
 	},
 	{
 		image: '/images/500x200.svg',
 		title: 'My project 3',
 		buttonAction: undefined,
+		navigate: action('Clicked on My project 3'),
 	},
 ];

--- a/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.stories.tsx
+++ b/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.stories.tsx
@@ -1,16 +1,11 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
-import { action } from '../../helpers';
-
 import { BlockProjectsSpotlight } from './BlockProjectsSpotlight';
 import { MOCK_SPOTLIGHT_PROJECTS } from './BlockProjectsSpotlight.mock';
 
 storiesOf('blocks/BlockProjectsSpotlight', module)
 	.addParameters({ jest: ['BlockProjectsSpotlight'] })
 	.add('BlockProjectsSpotlight', () => (
-		<BlockProjectsSpotlight
-			elements={MOCK_SPOTLIGHT_PROJECTS}
-			navigate={action('clicked project')}
-		/>
+		<BlockProjectsSpotlight elements={MOCK_SPOTLIGHT_PROJECTS} />
 	));

--- a/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.test.tsx
+++ b/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.test.tsx
@@ -5,9 +5,7 @@ import { mount, shallow } from 'enzyme';
 import { BlockProjectsSpotlight } from './BlockProjectsSpotlight';
 import { MOCK_SPOTLIGHT_PROJECTS } from './BlockProjectsSpotlight.mock';
 
-const BlockProjectsSpotlightExample = (
-	<BlockProjectsSpotlight elements={MOCK_SPOTLIGHT_PROJECTS} navigate={() => {}} />
-);
+const BlockProjectsSpotlightExample = <BlockProjectsSpotlight elements={MOCK_SPOTLIGHT_PROJECTS} />;
 
 describe('<BlockProjectsSpotlight />', () => {
 	it('Should be able to render', () => {

--- a/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.tsx
+++ b/src/content-blocks/BlockProjectsSpotlight/BlockProjectsSpotlight.tsx
@@ -12,25 +12,17 @@ export interface ImageInfo {
 	title: string;
 	buttonAction?: ButtonAction;
 	className?: string;
+	navigate: () => void;
 }
 
 export interface BlockProjectsSpotlightProps extends DefaultProps {
 	elements: ImageInfo[];
-	navigate: (buttonAction: ButtonAction) => void;
 }
 
 export const BlockProjectsSpotlight: FunctionComponent<BlockProjectsSpotlightProps> = ({
 	elements,
-	navigate,
 	className,
 }) => {
-	const navigateToProject = (index: number) => {
-		const action = get(elements, [index, 'buttonAction']);
-		if (action && navigate) {
-			navigate(action);
-		}
-	};
-
 	function renderProject(index: number) {
 		if (!elements[index]) {
 			return null;
@@ -41,7 +33,7 @@ export const BlockProjectsSpotlight: FunctionComponent<BlockProjectsSpotlightPro
 					'u-clickable': !!get(elements, [index, 'buttonAction']),
 				})}
 				style={{ backgroundImage: `url(${get(elements, [index, 'image'])})` }}
-				onClick={() => navigateToProject(index)}
+				onClick={get(elements, [index, 'navigate'])}
 			>
 				<p>{get(elements, [index, 'title'])}</p>
 			</div>


### PR DESCRIPTION
This is how the CTA and buttons block do it, this way we have to write less exceptions in the client