### PR TITLE
fix(search-result): use lodash truncate instead of writing our own

### DIFF
--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -1,14 +1,8 @@
+import classnames from 'classnames';
+import { truncate } from 'lodash-es';
 import React, { FunctionComponent, ReactNode } from 'react';
 
-import classnames from 'classnames';
-
 import { useSlot } from '../../hooks/useSlot';
-import {
-	SearchResultSubtitle,
-	SearchResultThumbnail,
-	SearchResultTitle,
-} from './SearchResult.slots';
-
 import { DefaultProps, EnglishContentType } from '../../types';
 import { Flex } from '../Flex/Flex';
 import { FlexItem } from '../Flex/FlexItem/FlexItem';
@@ -19,7 +13,11 @@ import { TagList } from '../TagList/TagList';
 import { ToggleButton } from '../ToggleButton/ToggleButton';
 
 import './SearchResult.scss';
-import { truncate } from 'lodash-es';
+import {
+	SearchResultSubtitle,
+	SearchResultThumbnail,
+	SearchResultTitle,
+} from './SearchResult.slots';
 
 export interface SearchResultProps extends DefaultProps {
 	children: ReactNode;

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -19,6 +19,7 @@ import { TagList } from '../TagList/TagList';
 import { ToggleButton } from '../ToggleButton/ToggleButton';
 
 import './SearchResult.scss';
+import { truncate } from 'lodash-es';
 
 export interface SearchResultProps extends DefaultProps {
 	children: ReactNode;
@@ -49,13 +50,6 @@ export const SearchResult: FunctionComponent<SearchResultProps> = ({
 	const subTitle = useSlot(SearchResultSubtitle, children);
 	const thumbnail = useSlot(SearchResultThumbnail, children);
 
-	const getTruncatedDescription = () => {
-		if (description && description.length > maxDescriptionLength - 3) {
-			return `${description.substring(0, maxDescriptionLength)}...`;
-		}
-		return description;
-	};
-
 	return (
 		<div className={classnames(className, 'c-search-result')}>
 			<div className="c-search-result__image">{thumbnail}</div>
@@ -76,7 +70,9 @@ export const SearchResult: FunctionComponent<SearchResultProps> = ({
 						</div>
 					</FlexItem>
 				</Flex>
-				<p className="c-search-result__description">{getTruncatedDescription()}</p>
+				<p className="c-search-result__description">
+					{truncate(description, { length: maxDescriptionLength })}
+				</p>
 				<Spacer margin="bottom-small">
 					<Flex justify="between" wrap>
 						<MetaData category={type}>


### PR DESCRIPTION
We use the truncate function in the client already, so if we use the lodash function in both places, it will save bytes