### PR TITLE
feat(container): add full width option for hor containers

### DIFF
--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -51,6 +51,12 @@ $o-container-max-width: 130rem;
 	max-width: $o-container-max-width-large;
 }
 
+.o-container--full-width {
+	max-width: none;
+	padding-left: 1rem;
+	padding-right: 1rem;
+}
+
 @media (min-width: $g-bp2) {
 	.o-container-bp2 {
 		max-width: $o-container-max-width;

--- a/src/components/Container/Container.stories.tsx
+++ b/src/components/Container/Container.stories.tsx
@@ -13,6 +13,10 @@ storiesOf('components/Container', module)
 		<Fragment>
 			<Container mode="horizontal">{content}</Container>
 			<br />
+			<Container mode="horizontal" size="full-width">
+				{content}
+			</Container>
+			<br />
 			<Container mode="horizontal" size="large">
 				{content}
 			</Container>

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -8,7 +8,7 @@ import './Container.scss';
 
 export interface ContainerProps extends DefaultProps {
 	mode?: Orientation;
-	size?: 'small' | 'medium' | 'large';
+	size?: 'small' | 'medium' | 'large' | 'full-width';
 	background?: 'white' | 'alt' | 'inverse';
 	bordered?: boolean;
 	children: ReactNode;


### PR DESCRIPTION
This will be helpful to use the full page, when showing overview tables in the admin dashboard:

current behavior:
![image](https://user-images.githubusercontent.com/1710840/76411213-9fc33680-6391-11ea-8c37-fcb00fd8e58f.png)

behavior with full-width option:
![image](https://user-images.githubusercontent.com/1710840/76411228-a5b91780-6391-11ea-951d-063c651a6e27.png)
