### PR TITLE
fix(tag-input): fix issues when allowCreate is true, add translations

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import { DefaultProps } from '../../types';
 
 import './Select.scss';
+import CreatableSelect from 'react-select/creatable';
 
 export interface SelectOption<T = string> {
 	value: T;
@@ -56,6 +57,9 @@ export const Select: FunctionComponent<SelectProps> = ({
 			isOptionDisabled={option => !!option.disabled}
 			placeholder={placeholder}
 			onChange={onValueChange}
+			noOptionsMessage={() => 'Geen opties'}
+			loadingMessage={() => 'Bezig met laden'}
+			formatCreateLabel={(value: string) => `"${value}" aanmaken`}
 		/>
 	);
 };

--- a/src/components/TagsInput/TagsInput.stories.tsx
+++ b/src/components/TagsInput/TagsInput.stories.tsx
@@ -70,4 +70,11 @@ storiesOf('components/TagsInput', module)
 				<TagsInput options={tags} allowMulti={false} />
 			</TagsInputStoryComponent>
 		</Fragment>
+	))
+	.add('TagsInput isLoading', () => (
+		<Fragment>
+			<TagsInputStoryComponent>
+				<TagsInput options={tags} isLoading={true} />
+			</TagsInputStoryComponent>
+		</Fragment>
 	));

--- a/src/components/TagsInput/TagsInput.stories.tsx
+++ b/src/components/TagsInput/TagsInput.stories.tsx
@@ -17,10 +17,13 @@ const TagsInputStoryComponent = ({
 
 	return cloneElement(children, {
 		value,
-		onChange: (changedValue: TagInfo[]) => {
-			action('tags input changed')(value);
-
-			setValue([...value, ...changedValue]);
+		onChange: (changedValues: TagInfo[]) => {
+			action('tags input changed')(changedValues);
+			setValue(changedValues);
+		},
+		onCreate: (tagToBeCreated: TagInfo) => {
+			action('creating tag')(tagToBeCreated);
+			setValue([...value, tagToBeCreated]);
 		},
 	});
 };
@@ -64,7 +67,7 @@ storiesOf('components/TagsInput', module)
 	.add('TagsInput single value', () => (
 		<Fragment>
 			<TagsInputStoryComponent>
-				<TagsInput options={tags} isMulti={false} />
+				<TagsInput options={tags} allowMulti={false} />
 			</TagsInputStoryComponent>
 		</Fragment>
 	));

--- a/src/components/TagsInput/TagsInput.stories.tsx
+++ b/src/components/TagsInput/TagsInput.stories.tsx
@@ -74,7 +74,7 @@ storiesOf('components/TagsInput', module)
 	.add('TagsInput isLoading', () => (
 		<Fragment>
 			<TagsInputStoryComponent>
-				<TagsInput options={tags} isLoading={true} />
+				<TagsInput options={[]} isLoading={true} />
 			</TagsInputStoryComponent>
 		</Fragment>
 	));

--- a/src/components/TagsInput/TagsInput.tsx
+++ b/src/components/TagsInput/TagsInput.tsx
@@ -21,7 +21,7 @@ export interface TagsInputProps extends DefaultProps {
 	value?: TagInfo[];
 	className?: string;
 	placeholder?: string;
-	isMulti?: boolean;
+	allowMulti?: boolean;
 	allowCreate?: boolean;
 	onChange?: (selectedValues: TagInfo[]) => void;
 	onCreate?: (value: TagInfo) => void;
@@ -31,7 +31,7 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 	options,
 	id,
 	disabled = false,
-	isMulti = true,
+	allowMulti = true,
 	value = [],
 	className = '',
 	placeholder = '',
@@ -39,14 +39,19 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 	onChange = () => {},
 	onCreate = () => {},
 }) => {
-	function onValueChange(changedValue: ValueType<TagInfo>, actionMeta: ActionMeta) {
-		if (!value) {
-			return;
-		}
+	function onValueChange(changedValues: ValueType<TagInfo>, actionMeta: ActionMeta) {
 		if (actionMeta.action === 'create-option') {
-			onCreate(changedValue as TagInfo);
+			const tagsToCreate: TagInfo[] = ((changedValues as TagInfo[]) || []).filter(
+				tag => (tag as any).__isNew__
+			);
+			if (tagsToCreate[0]) {
+				onCreate({
+					label: tagsToCreate[0].label,
+					value: tagsToCreate[0].value,
+				});
+			}
 		} else {
-			onChange(changedValue as TagInfo[]);
+			onChange(changedValues as TagInfo[]);
 		}
 	}
 
@@ -62,7 +67,7 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 			isDisabled={disabled}
 			placeholder={placeholder}
 			isSearchable={true}
-			isMulti={isMulti}
+			isMulti={allowMulti}
 			onChange={onValueChange}
 		/>
 	) : (
@@ -75,7 +80,7 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 			isDisabled={disabled}
 			placeholder={placeholder}
 			isSearchable={true}
-			isMulti={isMulti}
+			isMulti={allowMulti}
 			onChange={onValueChange}
 		/>
 	);

--- a/src/components/TagsInput/TagsInput.tsx
+++ b/src/components/TagsInput/TagsInput.tsx
@@ -72,6 +72,9 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 			isMulti={allowMulti}
 			isLoading={isLoading}
 			onChange={onValueChange}
+			noOptionsMessage={() => 'Geen opties'}
+			loadingMessage={() => 'Bezig met laden'}
+			formatCreateLabel={(value: string) => `"${value}" aanmaken`}
 		/>
 	) : (
 		<Select
@@ -86,6 +89,9 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 			isMulti={allowMulti}
 			isLoading={isLoading}
 			onChange={onValueChange}
+			noOptionsMessage={() => 'Geen opties'}
+			loadingMessage={() => 'Bezig met laden'}
+			formatCreateLabel={(value: string) => `"${value}" aanmaken`}
 		/>
 	);
 };

--- a/src/components/TagsInput/TagsInput.tsx
+++ b/src/components/TagsInput/TagsInput.tsx
@@ -23,6 +23,7 @@ export interface TagsInputProps extends DefaultProps {
 	placeholder?: string;
 	allowMulti?: boolean;
 	allowCreate?: boolean;
+	isLoading?: boolean;
 	onChange?: (selectedValues: TagInfo[]) => void;
 	onCreate?: (value: TagInfo) => void;
 }
@@ -36,6 +37,7 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 	className = '',
 	placeholder = '',
 	allowCreate = false,
+	isLoading = false,
 	onChange = () => {},
 	onCreate = () => {},
 }) => {
@@ -68,6 +70,7 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 			placeholder={placeholder}
 			isSearchable={true}
 			isMulti={allowMulti}
+			isLoading={isLoading}
 			onChange={onValueChange}
 		/>
 	) : (
@@ -81,6 +84,7 @@ export const TagsInput: FunctionComponent<TagsInputProps> = ({
 			placeholder={placeholder}
 			isSearchable={true}
 			isMulti={allowMulti}
+			isLoading={isLoading}
 			onChange={onValueChange}
 		/>
 	);


### PR DESCRIPTION
The object passed to the onCreate handler was wrong, it should be the created tagOption.
Also fixed some issues with the story actions for tagInput

![image](https://user-images.githubusercontent.com/1710840/76546110-3889ad00-648b-11ea-9ae7-0fcf3a1ff50d.png)

![image](https://user-images.githubusercontent.com/1710840/76548080-7f2cd680-648e-11ea-9915-ee15615407f3.png)

![image](https://user-images.githubusercontent.com/1710840/76548093-82c05d80-648e-11ea-8314-d1bb3b3fbaae.png)

![image](https://user-images.githubusercontent.com/1710840/76548103-85bb4e00-648e-11ea-86c5-f2549b50a716.png)
