### PR TITLE
fix(accordion): ensure text is dark even when in dark container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@viaa/avo2-components",
-  "version": "1.32.0",
+  "version": "1.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Accordion/Accordion.scss
+++ b/src/components/Accordion/Accordion.scss
@@ -58,6 +58,8 @@ $c-accordion-border: $color-gray-100 !default;
 	padding: 0.8rem 1.6rem;
 }
 
+
 .c-accordion__body {
 	border-top: 1px solid $c-accordion-border;
+	color: $color-gray-700 !important;
 }

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -67,4 +67,19 @@ storiesOf('components/Accordion', module)
 				<p>{loremIpsum({ count: 10 })}</p>
 			</div>
 		</Accordion>
+	))
+	.add('Accordion dark container', () => (
+		<div
+			className="u-color-white"
+			style={{
+				backgroundColor: '#2B414F',
+				padding: '20px',
+			}}
+		>
+			<Accordion title="Accordion title">
+				<div className="c-content">
+					<p>{loremIpsum({ count: 10 })}</p>
+				</div>
+			</Accordion>
+		</div>
 	));


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-174

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/77636396-54458680-6f54-11ea-881d-43cf5268169a.png)|![image](https://user-images.githubusercontent.com/1710840/77636409-590a3a80-6f54-11ea-994e-84f6da34bd4d.png)|
