### PR TITLE
fix(table): do not hide the border for the last row

### DIFF
--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -70,12 +70,6 @@ $c-table-row-selected-bg: $color-primary !default;
 		}
 	}
 
-	tr:last-child {
-		td {
-			border: none;
-		}
-	}
-
 	td,
 	th {
 		padding: 1.6rem;


### PR DESCRIPTION
wtf mono, why would you do this?

![image](https://user-images.githubusercontent.com/1710840/78265402-ae21ef80-7504-11ea-9ab3-a41581ea1201.png)
