### PR TITLE
fix(wysiwyg): add explanation for link target

### DIFF
--- a/src/components/WYSIWYG/WYSIWYG.scss
+++ b/src/components/WYSIWYG/WYSIWYG.scss
@@ -39,3 +39,23 @@
 		max-height: 100vh;
 	}
 }
+
+.trumbowyg-modal {
+	max-width: 553px !important;
+}
+
+.trumbowyg-modal-box {
+	max-width: 533px !important;
+}
+
+.trumbowyg-modal-box label:last-child {
+	height: 60px !important;
+}
+
+.trumbowyg-modal-box label input:last-child {
+	height: 52px !important;
+}
+
+.trumbowyg-modal-box label {
+	margin: 5px 12px !important;
+}

--- a/src/components/WYSIWYG/WYSIWYG.tsx
+++ b/src/components/WYSIWYG/WYSIWYG.tsx
@@ -10,6 +10,10 @@ import iconsPath from 'trumbowyg/dist/ui/icons.svg';
 import './WYSIWYG.scss';
 
 ($ as any).trumbowyg.svgPath = iconsPath;
+($ as any).trumbowyg.langs.nl = {
+	...($ as any).trumbowyg.langs.nl,
+	target: '_blank (nieuwe tab)<br/>_self (zelfde tab)',
+};
 
 type TrumbowygEvent = (e: JQuery.Event) => void;
 
@@ -118,7 +122,7 @@ export class WYSIWYG extends React.Component<WYSIWYGProps> {
 			this.editor.trumbowyg('destroy');
 			this.editor.trumbowyg({
 				lang: 'nl',
-				defaultLinkTarget: '_self',
+				defaultLinkTarget: '_blank',
 				...props,
 				onChange: this.handleChange,
 			});


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-89

![image](https://user-images.githubusercontent.com/1710840/78279572-044c5e00-7518-11ea-901d-3334603a0c0c.png)
