### PR TITLE
fix(quote): remove colored border from quote

### DIFF
--- a/src/styles/components/_content.scss
+++ b/src/styles/components/_content.scss
@@ -165,7 +165,6 @@
 		font-style: italic;
 		padding-left: 1.5rem;
 		margin-left: 0.2rem;
-		border-left: 0.4rem solid $color-night-blue;
 	}
 
 	table {


### PR DESCRIPTION
related to: https://district01.atlassian.net/browse/AVO2-1050

seem like the fix added a colored border:
![image](https://user-images.githubusercontent.com/1710840/78539958-ae1b3b80-77f3-11ea-923d-4808319cbc40.png)
