### PR TITLE
fix(modal): ensure non scrollable modals are overflow visible

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -167,8 +167,14 @@ $g-c-modal-z: 50 !default;
 	height: auto;
 }
 
-.c-modal--scrollable {
-	max-height: calc(100% - #{$c-modal-padding-vertical * 2});
+.c-modal {
+	&.c-modal--scrollable {
+		max-height: calc(100% - #{$c-modal-padding-vertical * 2});
+	}
+
+	&:not(.c-modal--scrollable) {
+		overflow: visible;
+	}
 }
 
 /* Backdrop


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-109

This fixes the issue where a dropdown or date select control is cut off in a modal:

![image](https://user-images.githubusercontent.com/1710840/79463411-1c80aa80-7ff9-11ea-94a0-67b33c8e7f54.png)


