### PR TITLE
feat(block-media-list): pass cta color params to cta block

### DIFF
--- a/src/content-blocks/BlockMediaList/BlockMediaList.mock.ts
+++ b/src/content-blocks/BlockMediaList/BlockMediaList.mock.ts
@@ -62,7 +62,16 @@ export const MEDIA_LIST_MOCK: MediaListItem[] = [
 ];
 
 export const MEDIA_LIST_CTA_MOCK = {
-	ctaButtonLabel: 'Ontdek meer',
-	ctaContent: 'Wil je meer weten?',
 	ctaTitle: 'Call to action',
+	ctaContent: 'Wil je meer weten?',
+	ctaButtonLabel: 'Ontdek meer',
+};
+
+export const MEDIA_LIST_COLORED_CTA_MOCK = {
+	ctaTitle: 'Call to action',
+	ctaTitleColor: '#FF0000',
+	ctaContent: 'Wil je meer weten?',
+	ctaContentColor: '#00FF00',
+	ctaButtonLabel: 'Ontdek meer',
+	ctaBackgroundColor: '#0000FF',
 };

--- a/src/content-blocks/BlockMediaList/BlockMediaList.stories.tsx
+++ b/src/content-blocks/BlockMediaList/BlockMediaList.stories.tsx
@@ -4,7 +4,11 @@ import React from 'react';
 import { action } from '../../helpers';
 
 import { BlockMediaList } from './BlockMediaList';
-import { MEDIA_LIST_CTA_MOCK, MEDIA_LIST_MOCK } from './BlockMediaList.mock';
+import {
+	MEDIA_LIST_COLORED_CTA_MOCK,
+	MEDIA_LIST_CTA_MOCK,
+	MEDIA_LIST_MOCK,
+} from './BlockMediaList.mock';
 
 storiesOf('blocks/BlockMediaList', module)
 	.addParameters({ jest: ['BlockMediaList'] })
@@ -16,5 +20,12 @@ storiesOf('blocks/BlockMediaList', module)
 			elements={MEDIA_LIST_MOCK.slice(0, -1)}
 			ctaNavigate={action('Clicked media')}
 			{...MEDIA_LIST_CTA_MOCK}
+		/>
+	))
+	.add('BlockMediaList with colored CTA', () => (
+		<BlockMediaList
+			elements={MEDIA_LIST_MOCK.slice(0, -1)}
+			ctaNavigate={action('Clicked media')}
+			{...MEDIA_LIST_COLORED_CTA_MOCK}
 		/>
 	));

--- a/src/content-blocks/BlockMediaList/BlockMediaList.tsx
+++ b/src/content-blocks/BlockMediaList/BlockMediaList.tsx
@@ -25,20 +25,28 @@ export type MediaListItem = {
 };
 
 export interface BlockMediaListProps extends DefaultProps {
-	ctaButtonLabel?: string;
-	ctaContent?: string;
-	ctaNavigate?: () => void;
 	ctaTitle?: string;
+	ctaTitleColor?: string;
+	ctaContent?: string;
+	ctaContentColor?: string;
+	ctaButtonLabel?: string;
+	ctaBackgroundColor?: string;
+	ctaWidth?: string;
+	ctaNavigate?: () => void;
 	elements: MediaListItem[];
 	orientation?: Orientation;
 }
 
 export const BlockMediaList: FunctionComponent<BlockMediaListProps> = ({
-	className,
-	ctaButtonLabel = '',
-	ctaContent = '',
-	ctaNavigate = () => {},
 	ctaTitle = '',
+	ctaTitleColor,
+	ctaContent = '',
+	ctaContentColor,
+	ctaButtonLabel = '',
+	ctaBackgroundColor,
+	ctaWidth = '100%',
+	ctaNavigate = () => {},
+	className,
 	elements = [],
 	orientation,
 }) => {
@@ -77,9 +85,13 @@ export const BlockMediaList: FunctionComponent<BlockMediaListProps> = ({
 						<CTA
 							buttonLabel={ctaButtonLabel}
 							heading={ctaTitle}
+							headingColor={ctaTitleColor}
 							content={ctaContent}
+							contentColor={ctaContentColor}
 							headingType="h3"
+							backgroundColor={ctaBackgroundColor}
 							navigate={ctaNavigate}
+							width={ctaWidth}
 						/>
 					</Column>
 				)}


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-216

client PR twin: https://github.com/viaacode/avo2-client/pull/591

![image](https://user-images.githubusercontent.com/1710840/79968207-132b8e00-8490-11ea-8d27-56f9e73c69d0.png)
