### PR TITLE
fix(header): allow title to wrap when it is too long

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,0 +1,3 @@
+.c-toolbar__left, .c-toolbar__right {
+	flex: initial;
+}

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -9,6 +9,8 @@ import { TagList } from '../TagList/TagList';
 import { Header } from './Header';
 import { MOCK_HEADER_PROPS, MOCK_HEADER_PROPS_FULL } from './Header.mock';
 import { HeaderAvatar, HeaderButtons, HeaderTags } from './Header.slots';
+import { ButtonToolbar } from '..';
+import { times } from 'lodash-es';
 
 storiesOf('components/Header', module)
 	.addParameters({ jest: ['Header'] })
@@ -33,5 +35,24 @@ storiesOf('components/Header', module)
 					]}
 				/>
 			</HeaderTags>
+		</Header>
+	))
+	.add('Header with long title', () => (
+		<Header
+			{...MOCK_HEADER_PROPS_FULL}
+			title="overlap video test Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras convallis odio udgse sdfes se"
+		>
+			<HeaderButtons>
+				<ButtonToolbar>
+					{times(4).map(index => (
+						<Button
+							type="secondary"
+							label="Bekijk"
+							onClick={() => null}
+							key={`header-button-${index}`}
+						/>
+					))}
+				</ButtonToolbar>
+			</HeaderButtons>
 		</Header>
 	));

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,16 +1,16 @@
+import { times } from 'lodash-es';
 import React from 'react';
 
 import { storiesOf } from '@storybook/react';
 
 import { Avatar } from '../Avatar/Avatar';
 import { Button } from '../Button/Button';
+import { ButtonToolbar } from '../ButtonToolbar/ButtonToolbar';
 import { TagList } from '../TagList/TagList';
 
 import { Header } from './Header';
 import { MOCK_HEADER_PROPS, MOCK_HEADER_PROPS_FULL } from './Header.mock';
 import { HeaderAvatar, HeaderButtons, HeaderTags } from './Header.slots';
-import { ButtonToolbar } from '..';
-import { times } from 'lodash-es';
 
 storiesOf('components/Header', module)
 	.addParameters({ jest: ['Header'] })

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,6 +15,7 @@ import { ToolbarLeft, ToolbarRight } from '../Toolbar/Toolbar.slots';
 import { ToolbarItem } from '../Toolbar/ToolbarItem/ToolbarItem';
 
 import { HeaderAvatar, HeaderButtons, HeaderTags } from './Header.slots';
+import './Header.scss';
 
 export interface HeaderPropsSchema extends DefaultProps {
 	bookmarks?: string;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,8 +14,8 @@ import { Toolbar } from '../Toolbar/Toolbar';
 import { ToolbarLeft, ToolbarRight } from '../Toolbar/Toolbar.slots';
 import { ToolbarItem } from '../Toolbar/ToolbarItem/ToolbarItem';
 
-import { HeaderAvatar, HeaderButtons, HeaderTags } from './Header.slots';
 import './Header.scss';
+import { HeaderAvatar, HeaderButtons, HeaderTags } from './Header.slots';
 
 export interface HeaderPropsSchema extends DefaultProps {
 	bookmarks?: string;


### PR DESCRIPTION
closes:
* https://meemoo.atlassian.net/browse/AVO-631
* https://meemoo.atlassian.net/browse/AVO-669

components:
![image](https://user-images.githubusercontent.com/1710840/80128291-b914f080-8595-11ea-8da9-cc5c7f2d357e.png)


This also fixes the issues in the client, without any changes needed in the client repo:
![image](https://user-images.githubusercontent.com/1710840/80128322-c6ca7600-8595-11ea-8a43-ba4aaf5f6a71.png)
