### PR TITLE
fix(toolbar): content items of toolbar should always be full width

### DIFF
--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -21,7 +21,7 @@ $c-toolbar-main-border-color: $color-gray-200 !default;
 	display: flex;
 	flex-shrink: 0;
 	align-items: center;
-	justify-content: space-around;
+	justify-content: space-between;
 	height: $g-bar-size-regular;
 }
 


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-669

![image](https://user-images.githubusercontent.com/1710840/80734831-0b16c280-8b10-11ea-939c-824502f1c684.png)

![image](https://user-images.githubusercontent.com/1710840/80734839-0ce08600-8b10-11ea-80b5-2de2f43c13ef.png)


