### PR TITLE
fix(page-overview-block): set better key for tiles in grid view

### DIFF
--- a/src/content-blocks/BlockGrid/BlockGrid.tsx
+++ b/src/content-blocks/BlockGrid/BlockGrid.tsx
@@ -5,6 +5,7 @@ import { Button, ButtonType, Spacer } from '../../components';
 import { AlignOptions, ButtonAction, DefaultProps } from '../../types';
 
 import './BlockGrid.scss';
+import { get } from 'lodash-es';
 
 export interface GridItem {
 	source: string;
@@ -48,7 +49,7 @@ export const BlockGrid: FunctionComponent<BlockGridProps> = ({
 		>
 			{elements.map(element => (
 				<div
-					key={`block-grid-${element.title}-${element.source}`}
+					key={`block-grid-${get(element, 'action.value')}`}
 					className={classnames('c-block-grid__item', {
 						'u-clickable': !!navigate && !!element.action,
 					})}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-745

items do not duplicate anymore when toggling the title
![image](https://user-images.githubusercontent.com/1710840/81850015-aa4ba900-9557-11ea-9c63-2922b0928d6e.png)

![image](https://user-images.githubusercontent.com/1710840/81850024-acae0300-9557-11ea-9052-a6e6e75cc73d.png)

![image](https://user-images.githubusercontent.com/1710840/81850034-afa8f380-9557-11ea-951e-c346ff7fa3b3.png)
