### PR TITLE
fix(modal): overflow when scrollable

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -174,6 +174,10 @@ $g-c-modal-z: 50 !default;
 
 	&:not(.c-modal--scrollable) {
 		overflow: visible;
+
+		.c-modal__body {
+			overflow: visible;
+		}
 	}
 }
 


### PR DESCRIPTION
This caused the date-picker to not overflow visibly, now it will.

![image](https://user-images.githubusercontent.com/36598928/82309209-25cbb100-99c3-11ea-964e-4593766e2095.png)
