### PR TITLE
feat(table): add option to show rows as cards, eg on mobile

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -182,4 +182,15 @@ storiesOf('components/Table', module)
 				showCheckboxes
 			/>
 		</TableStoryComponent>
+	))
+	.add('Table mobile cards', () => (
+		<TableStoryComponent>
+			<Table
+				columns={COLUMNS}
+				data={DATA}
+				rowKey="id"
+				renderCell={(row, cell) => renderCell(row, cell)}
+				useCards
+			/>
+		</TableStoryComponent>
 	));

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -10,6 +10,8 @@ import { IconNameSchema } from '../Icon/Icon.types';
 import { Spacer } from '../Spacer/Spacer';
 
 import './Table.scss';
+import { Panel } from '..';
+import { PanelBody } from '../Panel/PanelBody/PanelBody';
 
 export type TableColumnSchema = {
 	col?:
@@ -53,6 +55,7 @@ export interface TablePropsSchema extends DefaultProps {
 	untable?: boolean;
 	variant?: 'bordered' | 'invisible' | 'styled';
 	showCheckboxes?: boolean;
+	useCards?: boolean;
 	selectedItems?: any[];
 	onSelectionChanged?: (selectedItems: any[]) => void;
 }
@@ -76,6 +79,7 @@ export const Table: FunctionComponent<TablePropsSchema> = ({
 	untable,
 	variant,
 	showCheckboxes = false,
+	useCards = false,
 	selectedItems = [],
 	onSelectionChanged = () => {},
 }) => {
@@ -164,7 +168,7 @@ export const Table: FunctionComponent<TablePropsSchema> = ({
 		}
 	};
 
-	return (
+	const renderTable = () => (
 		<>
 			<table
 				className={classnames(className, 'c-table', {
@@ -239,4 +243,35 @@ export const Table: FunctionComponent<TablePropsSchema> = ({
 			)}
 		</>
 	);
+
+	const renderCards = () => {
+		if (!data || !rowKey) {
+			return null;
+		}
+		return (
+			<>
+				{(data || []).map((rowData, rowIndex) => (
+					<div
+						key={`table-card-${rowData[rowKey]}`}
+						className={onRowClick || showCheckboxes ? 'u-clickable' : ''}
+						onClick={() => handleRowClick(rowData)}
+					>
+						<Spacer margin="bottom">
+							<Panel>
+								<PanelBody>
+									{columns
+										.map(col => col.id)
+										.map((columnId, columnIndex) => (
+											<div>{renderCell(rowData, columnId, rowIndex, columnIndex)}</div>
+										))}
+								</PanelBody>
+							</Panel>
+						</Spacer>
+					</div>
+				))}
+			</>
+		);
+	};
+
+	return useCards ? renderCards() : renderTable();
 };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -262,7 +262,9 @@ export const Table: FunctionComponent<TablePropsSchema> = ({
 									{columns
 										.map(col => col.id)
 										.map((columnId, columnIndex) => (
-											<div>{renderCell(rowData, columnId, rowIndex, columnIndex)}</div>
+											<div key={columnIndex}>
+												{renderCell(rowData, columnId, rowIndex, columnIndex)}
+											</div>
 										))}
 								</PanelBody>
 							</Panel>


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-836

![image](https://user-images.githubusercontent.com/1710840/83532394-7af0e200-a4ee-11ea-87d8-7ccbdf97fd59.png)

Formatting of the "cell" content is still up to the consumer of this component using the renderCell function. So any padding can be added there