### PR TITLE
fix(flowplayer): hide header when video is not yet playing

### DIFF
--- a/src/components/FlowPlayer/FlowPlayer.scss
+++ b/src/components/FlowPlayer/FlowPlayer.scss
@@ -289,6 +289,11 @@ $c-video-player-progress-inner-bg: $color-teal-bright;
 		}
 	}
 
+	.is-starting .fp-header {
+		visibility: hidden;
+		display: none;
+	}
+
 	&.is-hovered,
 	&.is-paused {
 		.fp-header {


### PR DESCRIPTION
|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/84263834-7d6fbf00-ab20-11ea-85e3-106dd53ebfb9.png)|![image](https://user-images.githubusercontent.com/1710840/84263839-7f398280-ab20-11ea-92ea-916c63489dc0.png)|