### PR TITLE
fix(alert): remove top margin from heading if first elem in alert

### DIFF
--- a/src/components/Alert/Alert.scss
+++ b/src/components/Alert/Alert.scss
@@ -32,6 +32,14 @@ $c-dark-alert-bg-color: $color-gray-700 !default;
 	.o-svg-icon-button-actions-close {
 		cursor: pointer;
 	}
+
+	.c-content {
+		h1, h2, h3, h4, h5, h6 {
+			&:first-child {
+				margin-top: 0;
+			}
+		}
+	}
 }
 
 .c-alert__body {

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -52,4 +52,12 @@ storiesOf('components/Alert', module)
 				Info alert message <a href="#alert">with link</a>
 			</span>
 		</Alert>
+	))
+	.add('Alerts heading', () => (
+		<Alert>
+			<span className="c-content">
+				<h4>Test heading</h4>
+				Heading should not have any margin top
+			</span>
+		</Alert>
 	));


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-1190

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/87144542-305e4480-c2a8-11ea-9c69-f7a1ebe81063.png)|![image](https://user-images.githubusercontent.com/1710840/87144547-33593500-c2a8-11ea-9686-b5d520ba4e9c.png)|
