### PR TITLE
AVO-943 block image copyright icon

### DIFF
--- a/src/content-blocks/BlockImage/BlockImage.tsx
+++ b/src/content-blocks/BlockImage/BlockImage.tsx
@@ -54,7 +54,7 @@ export const BlockImage: FunctionComponent<BlockImageProps> = ({
 			)}
 			{(!!title || !!text) && (
 				<div className="a-block-image__annotation">
-					{title && <h3>{title}</h3>}
+					{title && <h3>&#169; {title}</h3>}
 					{text && <p className="a-block-image__text">{text}</p>}
 				</div>
 			)}


### PR DESCRIPTION
Resolves: https://meemoo.atlassian.net/browse/AVO-943

Enkel tonen indien de title property meegegeven is, as requested in ticket.

![image](https://user-images.githubusercontent.com/36598928/89634164-39413680-d8a5-11ea-832f-35053b155e9e.png)
