### PR TITLE
fix(toolbar): remove mono fix that causes more issues than it solves

### DIFF
--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -50,7 +50,6 @@ $c-toolbar-main-border-color: $color-gray-200 !default;
 }
 
 .c-toolbar__left {
-	z-index: $g-c-local-toolbar-z; // Left and right should have higher z-index than center; if the elements overlap, there is a bigger chance we can still tap the action most likely contained on the left or right end
 	justify-content: flex-start;
 
 	.c-toolbar__item {
@@ -63,7 +62,6 @@ $c-toolbar-main-border-color: $color-gray-200 !default;
 }
 
 .c-toolbar__right {
-	z-index: $g-c-local-toolbar-z; // Left and right should have higher z-index than center; if the elements overlap, there is a bigger chance we can still tap the action most likely contained on the left or right end
 	justify-content: flex-end;
 
 	.c-toolbar__item {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-354

toolbars should not have elevated z-index:
![image](https://user-images.githubusercontent.com/1710840/89770025-72281800-dafe-11ea-95fc-c6692d52bed1.png)

![image](https://user-images.githubusercontent.com/1710840/89770029-73594500-dafe-11ea-9cba-7a0ae6eae637.png)

![image](https://user-images.githubusercontent.com/1710840/89770135-9b48a880-dafe-11ea-86b2-4589cae20d05.png)
