### PR TITLE
feat(block-image-grid): split align into align and text-align

### DIFF
--- a/src/content-blocks/BlockImageGrid/BlockImageGrid.scss
+++ b/src/content-blocks/BlockImageGrid/BlockImageGrid.scss
@@ -32,13 +32,16 @@
 
 	.c-block-grid__button-spacer {
 		display: flex;
-		justify-content: center;
 	}
 
 	&.text-align-left {
 		h3,
 		p {
 			text-align: left;
+		}
+
+		.c-block-grid__button-spacer {
+			justify-content: flex-start;
 		}
 	}
 
@@ -47,6 +50,10 @@
 		p {
 			text-align: center;
 		}
+
+		.c-block-grid__button-spacer {
+			justify-content: center;
+		}
 	}
 
 	&.text-align-right {
@@ -54,21 +61,25 @@
 		p {
 			text-align: right;
 		}
+
+		.c-block-grid__button-spacer {
+			justify-content: flex-end;
+		}
 	}
 
 	&.item-align-left {
 		justify-content: flex-start;
 
-		.c-block-grid__button-spacer {
-			justify-content: flex-start;
+		.c-block-grid__item {
+			margin: 1rem 2rem 0 0;
 		}
 	}
 
 	&.item-align-right {
 		justify-content: flex-end;
 
-		.c-block-grid__button-spacer {
-			justify-content: flex-end;
+		.c-block-grid__item {
+			margin: 1rem 0 0 2rem;
 		}
 	}
 }

--- a/src/content-blocks/BlockImageGrid/BlockImageGrid.stories.tsx
+++ b/src/content-blocks/BlockImageGrid/BlockImageGrid.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { action } from '../../helpers';
 import { ButtonAction } from '../../types';
 
-import { BlockGrid, GridItem } from './BlockGrid';
+import { BlockImageGrid, GridItem } from './BlockImageGrid';
 
 const elements: GridItem[] = [
 	{ source: '/images/200x200.svg?id=0' },
@@ -36,6 +36,9 @@ const elements2: GridItem[] = [
 		text:
 			'Knip zelf relevante fragmenten uit het beschikbare beeldmateriaal en bewaar ze in een eigen collectie.',
 		action: { type: 'EXTERNAL_LINK', value: 'http://google.com' },
+		buttonLabel: 'a button',
+		buttonTitle: 'the button tooltip',
+		buttonType: 'inline-link',
 	},
 	{
 		source: '/images/500x200.svg?id=2',
@@ -94,14 +97,19 @@ const navigate = (buttonAction: ButtonAction) => {
 	window.location.href = buttonAction.value as string;
 };
 
-storiesOf('blocks/BlockGrid', module)
+storiesOf('blocks/BlockImageGrid', module)
 	.addParameters({ jest: ['Image'] })
-	.add('BlockGrid 200x200', () => <BlockGrid elements={elements} />)
-	.add('BlockGrid 500x200', () => (
-		<BlockGrid elements={elements2} imageWidth={500} imageHeight={200} navigate={navigate} />
+	.add('BlockImageGrid 200x200', () => <BlockImageGrid elements={elements} />)
+	.add('BlockImageGrid 500x200', () => (
+		<BlockImageGrid
+			elements={elements2}
+			imageWidth={500}
+			imageHeight={200}
+			navigate={navigate}
+		/>
 	))
-	.add('BlockGrid wider item then image', () => (
-		<BlockGrid
+	.add('BlockImageGrid wider item then image', () => (
+		<BlockImageGrid
 			elements={elements2}
 			imageWidth={200}
 			imageHeight={150}
@@ -109,9 +117,9 @@ storiesOf('blocks/BlockGrid', module)
 			navigate={navigate}
 		/>
 	))
-	.add('BlockGrid action', () => <BlockGrid elements={elements2} navigate={navigate} />)
-	.add('BlockGrid 150x150 fill contain', () => (
-		<BlockGrid
+	.add('BlockImageGrid action', () => <BlockImageGrid elements={elements2} navigate={navigate} />)
+	.add('BlockImageGrid 150x150 fill contain', () => (
+		<BlockImageGrid
 			elements={elements2}
 			imageWidth={150}
 			imageHeight={150}
@@ -119,8 +127,8 @@ storiesOf('blocks/BlockGrid', module)
 			navigate={navigate}
 		/>
 	))
-	.add('BlockGrid 150x150 fill cover', () => (
-		<BlockGrid
+	.add('BlockImageGrid 150x150 fill cover', () => (
+		<BlockImageGrid
 			elements={elements2}
 			imageWidth={150}
 			imageHeight={150}
@@ -128,8 +136,8 @@ storiesOf('blocks/BlockGrid', module)
 			navigate={navigate}
 		/>
 	))
-	.add('BlockGrid 150x150 fill auto', () => (
-		<BlockGrid
+	.add('BlockImageGrid 150x150 fill auto', () => (
+		<BlockImageGrid
 			elements={elements2}
 			imageWidth={150}
 			imageHeight={150}
@@ -137,6 +145,15 @@ storiesOf('blocks/BlockGrid', module)
 			navigate={navigate}
 		/>
 	))
-	.add('BlockGrid text right', () => (
-		<BlockGrid elements={elements2} textAlign="right" navigate={navigate} />
+	.add('BlockImageGrid align left', () => (
+		<BlockImageGrid elements={elements2} align="left" navigate={navigate} />
+	))
+	.add('BlockImageGrid align right', () => (
+		<BlockImageGrid elements={elements2} align="right" navigate={navigate} />
+	))
+	.add('BlockImageGrid align left align text right', () => (
+		<BlockImageGrid elements={elements2} align="left" textAlign="right" navigate={navigate} />
+	))
+	.add('BlockImageGrid align right align text left', () => (
+		<BlockImageGrid elements={elements2} align="right" textAlign="left" navigate={navigate} />
 	));

--- a/src/content-blocks/BlockImageGrid/BlockImageGrid.tsx
+++ b/src/content-blocks/BlockImageGrid/BlockImageGrid.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
+import { get } from 'lodash-es';
 import React, { FunctionComponent, ReactNode } from 'react';
 
 import { Button, ButtonType, Spacer } from '../../components';
 import { AlignOptions, ButtonAction, DefaultProps } from '../../types';
 
-import './BlockGrid.scss';
-import { get } from 'lodash-es';
+import './BlockImageGrid.scss';
 
 export interface GridItem {
 	source: string;
@@ -17,23 +17,25 @@ export interface GridItem {
 	action?: ButtonAction;
 }
 
-export interface BlockGridProps extends DefaultProps {
+export interface BlockImageGridProps extends DefaultProps {
 	elements: GridItem[];
 	imageWidth?: number;
 	imageHeight?: number;
 	itemWidth?: number;
 	fill?: 'cover' | 'contain' | 'auto';
+	align?: AlignOptions;
 	textAlign?: AlignOptions;
 	className?: string;
 	navigate?: (action: ButtonAction) => void;
 }
 
-export const BlockGrid: FunctionComponent<BlockGridProps> = ({
+export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
 	elements = [],
 	imageWidth = 200,
 	imageHeight = 200,
 	itemWidth = 200,
 	fill = 'cover',
+	align = 'center',
 	textAlign = 'center',
 	className,
 	navigate,
@@ -43,7 +45,7 @@ export const BlockGrid: FunctionComponent<BlockGridProps> = ({
 			className={classnames(
 				'c-block-grid',
 				`text-align-${textAlign}`,
-				`item-align-${textAlign}`,
+				`item-align-${align}`,
 				className
 			)}
 		>

--- a/src/content-blocks/BlockPageOverview/BlockPageOverview.tsx
+++ b/src/content-blocks/BlockPageOverview/BlockPageOverview.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../components';
 import { convertToHtml } from '../../helpers';
 import { ButtonAction, DefaultProps } from '../../types';
-import { BlockGrid, GridItem } from '../BlockGrid/BlockGrid';
+import { BlockImageGrid, GridItem } from '../BlockImageGrid/BlockImageGrid';
 import { BlockHeading } from '../BlockHeading/BlockHeading';
 
 import './BlockPageOverview.scss';
@@ -293,7 +293,7 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 								<BlockHeading type={'h2'}>{labelObj.label}</BlockHeading>
 							</Spacer>
 						)}
-						<BlockGrid
+						<BlockImageGrid
 							elements={(pagesByLabel[labelObj.id] || []).map(
 								(page: PageInfo): GridItem => ({
 									title: showTitle ? page.title : undefined,

--- a/src/content-blocks/index.ts
+++ b/src/content-blocks/index.ts
@@ -2,7 +2,7 @@
 export { BlockAccordions, BlockAccordionsProps } from './BlockAccordions/BlockAccordions';
 export { BlockButtons, BlockButtonsProps } from './BlockButtons/BlockButtons';
 export { BlockCTAs, BlockCTAsProps } from './BlockCTAs/BlockCTAs';
-export { BlockGrid, BlockGridProps, GridItem } from './BlockGrid/BlockGrid';
+export { BlockImageGrid, BlockImageGridProps, GridItem } from './BlockImageGrid/BlockImageGrid';
 export { BlockHeading, BlockHeadingProps } from './BlockHeading/BlockHeading';
 export { BlockIFrame, BlockIFrameProps } from './BlockIFrame/BlockIFrame';
 export { BlockIntro, BlockIntroProps } from './BlockIntro/BlockIntro';


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-188

also renamed block-grid to block-image-grid

![image](https://user-images.githubusercontent.com/1710840/89905187-281c6080-dbea-11ea-9b67-f09de86b29be.png)

![image](https://user-images.githubusercontent.com/1710840/89905197-2bafe780-dbea-11ea-8e45-883b7d570f57.png)

![image](https://user-images.githubusercontent.com/1710840/89905204-2d79ab00-dbea-11ea-8aef-576528d46fb5.png)

![image](https://user-images.githubusercontent.com/1710840/89905215-2fdc0500-dbea-11ea-8700-88090e778f5c.png)

