### PR TITLE
fix(flowplayer): fade in trackbar when video starts playing

### DIFF
--- a/src/components/FlowPlayer/FlowPlayer.scss
+++ b/src/components/FlowPlayer/FlowPlayer.scss
@@ -185,8 +185,36 @@ $c-video-player-progress-inner-bg: $color-teal-bright;
 		}
 	}
 
-	&.use-drag-handle .fp-controls:hover .fp-timeline {
-		height: 6px;
+	@keyframes delayedFadeIn {
+		0%   {opacity: 0}
+		75%  {opacity: 0}
+		100% {opacity: 1}
+	}
+
+	.fp-timeline {
+		opacity: 0;
+		animation: delayedFadeIn 1s linear;
+		animation-fill-mode: both;
+		animation-play-state: paused;
+	}
+
+	&.is-waiting,
+	&.is-playing,
+	&.is-paused,
+	&.is-ended {
+		.fp-timeline {
+			animation-play-state: running;
+		}
+	}
+
+	&.use-drag-handle .fp-controls:hover {
+		.fp-timeline {
+			height: 6px;
+		}
+
+		.dragger {
+			transform: scale(1.3);
+		}
 	}
 
 	.fp-progress,


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1067

to avoid nasty just from middle of trackbar to the start

before:
![old](https://user-images.githubusercontent.com/1710840/89922038-cdd9ca80-dbfe-11ea-9cab-eae4b6160b59.gif)

after:
![new](https://user-images.githubusercontent.com/1710840/89922064-d3cfab80-dbfe-11ea-8bdd-ce6692c528c6.gif)
