### PR TITLE
fix(block-spotlight): give spotlight items a height on mobile

### DIFF
--- a/src/content-blocks/BlockSpotlight/BlockSpotlight.scss
+++ b/src/content-blocks/BlockSpotlight/BlockSpotlight.scss
@@ -5,6 +5,10 @@
   c-project-grid
    ========================================================================== */
 
+.c-spotlight {
+	height: 500px;
+}
+
 @media (min-width: $g-bp2) {
 	.c-spotlight {
 		display: grid;
@@ -20,6 +24,7 @@
 	background-size: cover;
 	background-position: center;
 	background-repeat: no-repeat;
+	height: 200px;
 
 	p {
 		position: absolute;
@@ -42,6 +47,7 @@
 @media (min-width: $g-bp2) {
 	.c-spotlight__item {
 		margin: 0;
+		height: auto;
 	}
 
 	.c-spotlight__item:first-child {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-714

desktop works correct:
![image](https://user-images.githubusercontent.com/1710840/91725714-6a104500-eb9f-11ea-9a13-2b1537f9d87f.png)

mobile:
|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/91725741-72688000-eb9f-11ea-97ea-a4678e44adf0.png)|![image](https://user-images.githubusercontent.com/1710840/91725748-75637080-eb9f-11ea-9429-bcd8b35612f1.png)|

