### PR TITLE
fix(block-page-overview): center tabs inside flex center

### DIFF
--- a/src/content-blocks/BlockPageOverview/BlockPageOverview.scss
+++ b/src/content-blocks/BlockPageOverview/BlockPageOverview.scss
@@ -5,6 +5,10 @@
 		flex: initial;
 	}
 
+	.c-content-page-overview-block__header.o-flex--center .c-tag-list {
+		justify-content: center;
+	}
+
 	.c-content {
 
 		h2,

--- a/src/content-blocks/BlockPageOverview/BlockPageOverview.stories.tsx
+++ b/src/content-blocks/BlockPageOverview/BlockPageOverview.stories.tsx
@@ -1,10 +1,10 @@
 import { storiesOf } from '@storybook/react';
-import { intersectionBy } from 'lodash-es';
+import { intersectionBy, times } from 'lodash-es';
 import React, { cloneElement, ReactElement, useEffect, useState } from 'react';
 
 import { action } from '../../helpers';
 
-import { BlockPageOverview, PageInfo, LabelObj } from './BlockPageOverview';
+import { BlockPageOverview, LabelObj, PageInfo } from './BlockPageOverview';
 import { CONTENT_PAGES_MOCK } from './BlockPageOverview.mock';
 
 const tabs = [
@@ -13,7 +13,7 @@ const tabs = [
 ];
 
 const itemsPerPage = 2;
-const mockPages = CONTENT_PAGES_MOCK.map(page => ({
+const mockPages = CONTENT_PAGES_MOCK.map((page) => ({
 	...page,
 	blocks: <p>Test content page blocks</p>,
 }));
@@ -35,7 +35,7 @@ const BlockPageOverviewStoryComponent = ({
 	useEffect(() => {
 		let filteredPages: PageInfo[];
 		if (selectedTabs.length) {
-			filteredPages = mockPages.filter(page => {
+			filteredPages = mockPages.filter((page) => {
 				return !!intersectionBy(
 					page.labels,
 					selectedTabs,
@@ -166,6 +166,16 @@ storiesOf('blocks/BlockPageOverview', module)
 	.add('BlockPageOverview badges allow multiple', () => (
 		<BlockPageOverviewStoryComponent initialPageIndex={0}>
 			<BlockPageOverview {...baseProps} tabStyle={'ROUNDED_BADGES'} allowMultiple />
+		</BlockPageOverviewStoryComponent>
+	))
+	.add('BlockPageOverview badges wrapping and center', () => (
+		<BlockPageOverviewStoryComponent initialPageIndex={0}>
+			<BlockPageOverview
+				{...baseProps}
+				tabStyle={'ROUNDED_BADGES'}
+				tabs={times(20, (i) => ({ label: `label-${i}`, id: i }))}
+				centerHeader
+			/>
 		</BlockPageOverviewStoryComponent>
 	))
 	.add('BlockPageOverview show date', () => (


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-960

before:
![image](https://user-images.githubusercontent.com/1710840/91989399-c22a8100-ed30-11ea-9f6f-55f77d480fa3.png)

after:
![image](https://user-images.githubusercontent.com/1710840/91989413-c787cb80-ed30-11ea-8ece-75d37314c4de.png)
