### PR TITLE
fix(block-rich-text): make each text column full width on mobile

### DIFF
--- a/src/content-blocks/BlockRichText/BlockRichText.tsx
+++ b/src/content-blocks/BlockRichText/BlockRichText.tsx
@@ -64,7 +64,7 @@ export const BlockRichText: FunctionComponent<BlockRichTextProps> = ({
 		<Grid>
 			{elements.map((column, columnIndex) => (
 				<Column
-					size={(12 / elements.length).toString() as GridSizeSchema}
+					size={`2-${12 / elements.length}` as GridSizeSchema}
 					key={`rich-text-column-${columnIndex}`}
 				>
 					{renderContent(column, columnIndex)}


### PR DESCRIPTION
related to: https://meemoo.atlassian.net/browse/AVO-1290

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/96025212-1d35b480-0e55-11eb-8cae-41d9f0f67c95.png)|![image](https://user-images.githubusercontent.com/1710840/96025218-1eff7800-0e55-11eb-96d5-10b39ee87fa6.png)|