### PR TITLE
feat(navigate): replace navigate by renderLink

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@viaa/avo2-components",
-  "version": "1.58.1",
+  "version": "1.59.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@viaa/avo2-components",
-	"version": "1.58.1",
+	"version": "1.59.0",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/esm/index.d.ts",

--- a/src/components/CTA/CTA.mock.ts
+++ b/src/components/CTA/CTA.mock.ts
@@ -1,3 +1,7 @@
+import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
+import { LinkTarget } from '../../types';
+
 import { CTAPropsSchema } from './CTA';
 
 export const CTA_MOCK: CTAPropsSchema = {
@@ -6,5 +10,10 @@ export const CTA_MOCK: CTAPropsSchema = {
 	content: 'Text',
 	buttonLabel: 'Read more',
 	buttonIcon: 'chevron-down',
-	navigate: () => {},
+	buttonAction: {
+		target: LinkTarget.Blank,
+		type: 'EXTERNAL_LINK',
+		value: 'http://google.com',
+	},
+	renderLink: testRenderLink(action('navigate to')),
 };

--- a/src/components/CTA/CTA.tsx
+++ b/src/components/CTA/CTA.tsx
@@ -3,7 +3,8 @@ import React, { FunctionComponent } from 'react';
 
 import { BlockHeading } from '../../content-blocks/BlockHeading/BlockHeading';
 import { BlockRichText } from '../../content-blocks/BlockRichText/BlockRichText';
-import { ButtonAction, DefaultProps, HeadingType } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { ButtonAction, DefaultProps, HeadingType, RenderLinkFunction } from '../../types';
 import { Button, ButtonPropsSchema } from '../Button/Button';
 import { ButtonTypeSchema } from '../Button/Button.types';
 import { IconNameSchema } from '../Icon/Icon.types';
@@ -22,7 +23,7 @@ export interface CTAPropsSchema extends DefaultProps {
 	buttonAction?: ButtonAction;
 	width?: string;
 	backgroundColor?: string;
-	navigate: (buttonAction: ButtonAction) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const CTA: FunctionComponent<CTAPropsSchema> = ({
@@ -38,13 +39,12 @@ export const CTA: FunctionComponent<CTAPropsSchema> = ({
 	buttonAction,
 	width = '50%',
 	backgroundColor = '#EDEFF2',
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => {
 	const buttonProps: ButtonPropsSchema = {
 		label: buttonLabel,
 		title: buttonLabel,
 		ariaLabel: buttonLabel,
-		onClick: () => buttonAction && navigate(buttonAction),
 		icon: buttonIcon,
 		type: buttonType,
 	};
@@ -56,8 +56,11 @@ export const CTA: FunctionComponent<CTAPropsSchema> = ({
 					<BlockHeading type={headingType} color={headingColor}>
 						{heading}
 					</BlockHeading>
-					<BlockRichText elements={{ content, color: contentColor }} />
-					<Button {...buttonProps} />
+					<BlockRichText
+						elements={{ content, color: contentColor }}
+						renderLink={renderLink}
+					/>
+					{renderLink(buttonAction, <Button {...buttonProps} />)}
 				</div>
 			</div>
 		</div>

--- a/src/components/MediaCard/MediaCard.tsx
+++ b/src/components/MediaCard/MediaCard.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, MouseEvent, ReactNode } from 'react';
 
 import { useSlot } from '../../hooks/useSlot';
 import { DefaultProps, EnglishContentType, Orientation } from '../../types';
@@ -12,7 +12,7 @@ export interface MediaCardPropsSchema extends DefaultProps {
 	category: EnglishContentType;
 	children?: ReactNode;
 	orientation?: Orientation;
-	onClick?: () => void;
+	onClick?: (evt: MouseEvent<HTMLElement>) => void;
 }
 
 export const MediaCard: FunctionComponent<MediaCardPropsSchema> = ({
@@ -32,7 +32,7 @@ export const MediaCard: FunctionComponent<MediaCardPropsSchema> = ({
 				'c-media-card--horizontal': orientation === 'horizontal',
 				'u-clickable': !!onClick,
 			})}
-			onClick={() => onClick && onClick()}
+			onClick={(evt) => onClick && onClick(evt)}
 		>
 			{thumbnail && <div className="c-media-card-thumb">{thumbnail}</div>}
 			<div className="c-media-card-content">

--- a/src/content-blocks/BlockAccordions/BlockAccordions.tsx
+++ b/src/content-blocks/BlockAccordions/BlockAccordions.tsx
@@ -33,7 +33,9 @@ export const BlockAccordions: FunctionComponent<BlockAccordionsProps> = ({
 						key={key}
 						isOpen={accordionsOpen[key]}
 						title={title}
-						onToggle={() => setAccordionsOpen({ ...accordionsOpen, [key]: !accordionsOpen[key] })}
+						onToggle={() =>
+							setAccordionsOpen({ ...accordionsOpen, [key]: !accordionsOpen[key] })
+						}
 					>
 						<BlockRichText elements={{ content }} />
 					</Accordion>

--- a/src/content-blocks/BlockButtons/BlockButtons.stories.tsx
+++ b/src/content-blocks/BlockButtons/BlockButtons.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { ButtonTypeSchema } from '../../components/Button/Button.types';
 import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 import { AlignOptions } from '../../types';
 
 import { BlockButtons } from './BlockButtons';
@@ -18,7 +19,7 @@ const renderBlockButtons = (
 		elements={BUTTONS_MOCK.map((button) => ({ ...button, type }))}
 		align={align}
 		hasDividers={dividers}
-		navigate={action('button clicked')}
+		renderLink={testRenderLink(action('button clicked'))}
 	/>
 );
 
@@ -36,6 +37,6 @@ storiesOf('blocks/BlockButtons', module)
 			}))}
 			align="center"
 			hasDividers
-			navigate={action('button clicked')}
+			renderLink={testRenderLink(action('button clicked'))}
 		/>
 	));

--- a/src/content-blocks/BlockButtons/BlockButtons.test.tsx
+++ b/src/content-blocks/BlockButtons/BlockButtons.test.tsx
@@ -1,31 +1,41 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+
 import { BlockButtons } from './BlockButtons';
 import { BUTTONS_MOCK } from './BlockButtons.mock';
 
 describe('<BlockButtons />', () => {
 	it('Should be able to render', () => {
-		shallow(<BlockButtons elements={BUTTONS_MOCK} navigate={() => {}} />);
+		shallow(<BlockButtons elements={BUTTONS_MOCK} renderLink={defaultRenderLinkFunction} />);
 	});
 
 	it('should pass a custom className', () => {
 		const customClass = 'c-buttons-custom';
 		const ButtonsComponent = (
-			<BlockButtons className={customClass} elements={BUTTONS_MOCK} navigate={() => {}} />
+			<BlockButtons
+				className={customClass}
+				elements={BUTTONS_MOCK}
+				renderLink={defaultRenderLinkFunction}
+			/>
 		);
 
 		expect(shallow(ButtonsComponent).hasClass(customClass)).toBeTruthy();
 	});
 
 	it('Should correctly pass on elements prop', () => {
-		const ButtonsComponent = mount(<BlockButtons elements={BUTTONS_MOCK} navigate={() => {}} />);
+		const ButtonsComponent = mount(
+			<BlockButtons elements={BUTTONS_MOCK} renderLink={defaultRenderLinkFunction} />
+		);
 
 		expect(ButtonsComponent.prop('elements')).toEqual(BUTTONS_MOCK);
 	});
 
 	it('Should correctly render Buttons', () => {
-		const ButtonsComponent = mount(<BlockButtons elements={BUTTONS_MOCK} navigate={() => {}} />);
+		const ButtonsComponent = mount(
+			<BlockButtons elements={BUTTONS_MOCK} renderLink={defaultRenderLinkFunction} />
+		);
 		const buttonToolbar = ButtonsComponent.find('.c-button-toolbar');
 		const buttons = buttonToolbar.find('.c-button');
 

--- a/src/content-blocks/BlockButtons/BlockButtons.tsx
+++ b/src/content-blocks/BlockButtons/BlockButtons.tsx
@@ -3,7 +3,8 @@ import { flatten } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
 
 import { Button, ButtonToolbar, ButtonType, IconName } from '../../components';
-import { AlignOptions, ButtonAction, DefaultProps } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { AlignOptions, ButtonAction, DefaultProps, RenderLinkFunction } from '../../types';
 
 import './BlockButtons.scss';
 
@@ -26,7 +27,7 @@ export interface BlockButtonsProps extends DefaultProps {
 	elements: ButtonProps[];
 	align?: AlignOptions;
 	hasDividers?: boolean;
-	navigate: (buttonAction: ButtonAction) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const BlockButtons: FunctionComponent<BlockButtonsProps> = ({
@@ -34,7 +35,7 @@ export const BlockButtons: FunctionComponent<BlockButtonsProps> = ({
 	elements,
 	align = 'left',
 	hasDividers = false,
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => (
 	<ButtonToolbar
 		className={classnames(className, 'c-block-buttons', `u-content-flex--${align}`, {
@@ -45,12 +46,10 @@ export const BlockButtons: FunctionComponent<BlockButtonsProps> = ({
 			elements.map((button, index) => {
 				const nodes = [
 					<div key={`buttons_block_${button.label}`}>
-						<Button
-							key={`button-${index}`}
-							type="secondary"
-							{...button}
-							onClick={() => navigate(button.buttonAction)}
-						/>
+						{renderLink(
+							button.buttonAction,
+							<Button key={`button-${index}`} type="secondary" {...button} />
+						)}
 					</div>,
 				];
 				if (hasDividers && index !== elements.length - 1) {

--- a/src/content-blocks/BlockCTAs/BlockCTAs.mock.ts
+++ b/src/content-blocks/BlockCTAs/BlockCTAs.mock.ts
@@ -2,6 +2,7 @@ import { loremIpsum } from 'lorem-ipsum';
 
 import { CTAProps } from '../../components';
 import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 import { LinkTarget } from '../../types';
 
 const content = loremIpsum({ count: 10 });
@@ -17,7 +18,7 @@ export const CTAS_MOCK: CTAProps[] = [
 			value: 'https://google.com',
 			target: LinkTarget.Blank,
 		},
-		navigate: action('CTA 1'),
+		renderLink: testRenderLink(action('CTA 1')),
 	},
 	{
 		content,
@@ -33,6 +34,6 @@ export const CTAS_MOCK: CTAProps[] = [
 			value: 'https://google.com',
 			target: LinkTarget.Blank,
 		},
-		navigate: action('CTA 2'),
+		renderLink: testRenderLink(action('CTA 2')),
 	},
 ];

--- a/src/content-blocks/BlockCTAs/BlockCTAs.stories.tsx
+++ b/src/content-blocks/BlockCTAs/BlockCTAs.stories.tsx
@@ -1,15 +1,17 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 
 import { BlockCTAs } from './BlockCTAs';
 import { CTAS_MOCK } from './BlockCTAs.mock';
 
-const navigate = action('navigate to');
+const renderLink = testRenderLink(action('navigate to'));
 storiesOf('blocks/BlockCTAs', module)
 	.addParameters({ jest: ['BlockCTAs'] })
-	.add('BlockCTAs', () => <BlockCTAs elements={CTAS_MOCK} navigate={navigate} />)
-	.add('BlockCTA single', () => <BlockCTAs elements={[CTAS_MOCK[0]]} navigate={navigate} />)
+	.add('BlockCTAs', () => <BlockCTAs elements={CTAS_MOCK} renderLink={renderLink} />)
+	.add('BlockCTA single', () => <BlockCTAs elements={[CTAS_MOCK[0]]} renderLink={renderLink} />)
 	.add('BlockCTA narrow', () => (
-		<BlockCTAs elements={CTAS_MOCK} width="30%" navigate={navigate} />
+		<BlockCTAs elements={CTAS_MOCK} width="30%" renderLink={renderLink} />
 	));

--- a/src/content-blocks/BlockCTAs/BlockCTAs.test.tsx
+++ b/src/content-blocks/BlockCTAs/BlockCTAs.test.tsx
@@ -1,34 +1,35 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { action } from '../../helpers';
+import { testRenderLink } from "../../helpers/render-link";
 
 import { BlockCTAs } from './BlockCTAs';
 import { CTAS_MOCK } from './BlockCTAs.mock';
 
-const navigate = action('navigate to');
+const renderLink = testRenderLink(action('navigate to'));
 
 describe('<BlockCTAs />', () => {
 	it('Should be able to render', () => {
-		shallow(<BlockCTAs elements={CTAS_MOCK} navigate={navigate} />);
+		shallow(<BlockCTAs elements={CTAS_MOCK} renderLink={renderLink} />);
 	});
 
 	it('should pass a custom className', () => {
 		const customClass = 'c-cta-custom';
 		const CTAsComponent = (
-			<BlockCTAs className={customClass} elements={CTAS_MOCK} navigate={navigate} />
+			<BlockCTAs className={customClass} elements={CTAS_MOCK} renderLink={renderLink} />
 		);
 
 		expect(shallow(CTAsComponent).hasClass(customClass)).toBeTruthy();
 	});
 
 	it('Should correctly pass on elements prop', () => {
-		const CTAsComponent = mount(<BlockCTAs elements={CTAS_MOCK} navigate={navigate} />);
+		const CTAsComponent = mount(<BlockCTAs elements={CTAS_MOCK} renderLink={renderLink} />);
 
 		expect(CTAsComponent.prop('elements')).toEqual(CTAS_MOCK);
 	});
 
 	it('Should correctly render CTAs', () => {
-		const CTAsComponent = mount(<BlockCTAs elements={CTAS_MOCK} navigate={navigate} />);
+		const CTAsComponent = mount(<BlockCTAs elements={CTAS_MOCK} renderLink={renderLink} />);
 		const CTAsBlock = CTAsComponent.find('.c-cta');
 		const CTAs = CTAsBlock.find('.c-cta-item');
 

--- a/src/content-blocks/BlockCTAs/BlockCTAs.tsx
+++ b/src/content-blocks/BlockCTAs/BlockCTAs.tsx
@@ -2,26 +2,27 @@ import classnames from 'classnames';
 import React, { FunctionComponent } from 'react';
 
 import { CTA, CTAProps } from '../../components';
-import { ButtonAction, DefaultProps } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { DefaultProps, RenderLinkFunction } from '../../types';
 
 export interface BlockCTAsProps extends DefaultProps {
 	elements: CTAProps[];
 	width?: string;
-	navigate: (buttonAction: ButtonAction) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const BlockCTAs: FunctionComponent<BlockCTAsProps> = ({
 	className,
 	elements,
 	width,
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => (
 	<div className={classnames(className, 'c-cta')}>
 		{elements.map((cta, index) => (
 			<CTA
 				key={`cta-${index}`}
 				{...cta}
-				navigate={navigate}
+				renderLink={renderLink}
 				width={width || (elements.length === 1 ? '100%' : '50%')}
 			/>
 		))}

--- a/src/content-blocks/BlockHero/BlockHero.stories.tsx
+++ b/src/content-blocks/BlockHero/BlockHero.stories.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react';
 import { loremIpsum } from 'lorem-ipsum';
 import React from 'react';
 import { action } from '../../helpers';
+import { testRenderLink } from "../../helpers/render-link";
 
 import { BlockHero } from './BlockHero';
 import { ButtonProps } from '../../components';
@@ -30,6 +31,8 @@ const mockButtons: (ButtonProps & { buttonAction: ButtonAction })[] = [
 	},
 ];
 
+const renderLink = testRenderLink(action('navigate to'));
+
 storiesOf('blocks/BlockHero', module)
 	.addParameters({ jest: ['BlockHero'] })
 	.add('BlockHero video with poster', () => (
@@ -44,7 +47,7 @@ storiesOf('blocks/BlockHero', module)
 				textBelowButtons={
 					'<p>Lesgever en nog geen account?<br/><a href="/stamboek">Maak gratis een account aan.</a></p>'
 				}
-				navigate={action('navigate to')}
+				renderLink={renderLink}
 			/>
 		</div>
 	))
@@ -55,7 +58,7 @@ storiesOf('blocks/BlockHero', module)
 				content={loremIpsum({ count: 3 })}
 				src={mockVideo}
 				buttons={mockButtons}
-				navigate={action('navigate to')}
+				renderLink={renderLink}
 			/>
 		</div>
 	))
@@ -66,7 +69,7 @@ storiesOf('blocks/BlockHero', module)
 				content={loremIpsum({ count: 3 })}
 				poster={mockPoster}
 				buttons={mockButtons}
-				navigate={action('navigate to')}
+				renderLink={renderLink}
 			/>
 		</div>
 	))
@@ -77,7 +80,7 @@ storiesOf('blocks/BlockHero', module)
 				content={loremIpsum({ count: 3 })}
 				poster={mockPoster}
 				buttons={mockButtons}
-				navigate={action('navigate to')}
+				renderLink={renderLink}
 			/>
 		</div>
 	))
@@ -90,7 +93,7 @@ storiesOf('blocks/BlockHero', module)
 				contentColor="red"
 				poster={mockPoster}
 				buttons={mockButtons}
-				navigate={action('navigate to')}
+				renderLink={renderLink}
 			/>
 		</div>
 	));

--- a/src/content-blocks/BlockHero/BlockHero.tsx
+++ b/src/content-blocks/BlockHero/BlockHero.tsx
@@ -1,16 +1,17 @@
 import { isString } from 'lodash-es';
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactElement, ReactNode } from 'react';
 
-import { ButtonAction, DefaultProps } from '../../types';
-import { BlockHeading } from '../BlockHeading/BlockHeading';
 import {
-	ButtonToolbar,
-	FlowPlayer,
-	Spacer,
-	Container,
 	Button,
 	ButtonProps,
+	ButtonToolbar,
+	Container,
+	FlowPlayer,
+	Spacer,
 } from '../../components';
+import { defaultRenderLinkFunction } from "../../helpers/render-link";
+import { ButtonAction, DefaultProps } from '../../types';
+import { BlockHeading } from '../BlockHeading/BlockHeading';
 
 import './BlockHero.scss';
 
@@ -26,7 +27,7 @@ export interface BlockHeroProps extends DefaultProps {
 	dataPlayerId?: string;
 	buttons?: (ButtonProps & { buttonAction: ButtonAction })[];
 	textBelowButtons?: string | ReactNode;
-	navigate?: (buttonAction: ButtonAction) => void;
+	renderLink?: (buttonAction: ButtonAction, children: ReactNode) => ReactElement<any, any> | null;
 }
 
 export const BlockHero: FunctionComponent<BlockHeroProps> = ({
@@ -41,7 +42,7 @@ export const BlockHero: FunctionComponent<BlockHeroProps> = ({
 	dataPlayerId,
 	buttons = [],
 	textBelowButtons,
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => (
 	<Container mode="vertical" size="large">
 		<div className="c-tri__half-split" />
@@ -58,16 +59,13 @@ export const BlockHero: FunctionComponent<BlockHeroProps> = ({
 						{content}
 					</p>
 				</div>
-				{!!buttons && navigate && (
+				{!!buttons && (
 					<Spacer margin="top-large">
 						<ButtonToolbar>
 							{buttons.map(({ buttonAction, ...rest }, index: number) => {
-								return (
-									<Button
-										{...rest}
-										key={`hero-button-${index}`}
-										onClick={() => navigate(buttonAction)}
-									/>
+								return renderLink(
+									buttonAction,
+									<Button {...rest} key={`hero-button-${index}`} />
 								);
 							})}
 						</ButtonToolbar>

--- a/src/content-blocks/BlockImageGrid/BlockImageGrid.stories.tsx
+++ b/src/content-blocks/BlockImageGrid/BlockImageGrid.stories.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { action } from '../../helpers';
 import { ButtonAction } from '../../types';
@@ -92,20 +92,45 @@ const elements2: GridItem[] = [
 	},
 ];
 
-const navigate = (buttonAction: ButtonAction) => {
-	action('navigate')(buttonAction);
-	window.location.href = buttonAction.value as string;
+const elements3: GridItem[] = [
+	{
+		source: '/images/500x200.svg?id=0',
+		textAbove: 'meemoo',
+		action: { type: 'EXTERNAL_LINK', value: 'http://google.com' },
+	},
+	{
+		source: '/images/500x200.svg?id=1',
+		textAbove: 'vlaamse overheid',
+		action: { type: 'EXTERNAL_LINK', value: 'http://google.com' },
+	},
+];
+
+const renderLink = (buttonAction: ButtonAction | undefined | null, children: ReactNode) => {
+	return (
+		<div
+			onClick={() => {
+				if (buttonAction) {
+					action('navigate')(buttonAction);
+					window.location.href = buttonAction.value as string;
+				}
+			}}
+		>
+			{children}
+		</div>
+	);
 };
 
 storiesOf('blocks/BlockImageGrid', module)
 	.addParameters({ jest: ['Image'] })
-	.add('BlockImageGrid 200x200', () => <BlockImageGrid elements={elements} />)
+	.add('BlockImageGrid 200x200', () => (
+		<BlockImageGrid elements={elements} renderLink={renderLink} />
+	))
 	.add('BlockImageGrid 500x200', () => (
 		<BlockImageGrid
 			elements={elements2}
 			imageWidth={500}
 			imageHeight={200}
-			navigate={navigate}
+			renderLink={renderLink}
 		/>
 	))
 	.add('BlockImageGrid wider item then image', () => (
@@ -114,17 +139,19 @@ storiesOf('blocks/BlockImageGrid', module)
 			imageWidth={200}
 			imageHeight={150}
 			itemWidth={400}
-			navigate={navigate}
+			renderLink={renderLink}
 		/>
 	))
-	.add('BlockImageGrid action', () => <BlockImageGrid elements={elements2} navigate={navigate} />)
+	.add('BlockImageGrid action', () => (
+		<BlockImageGrid elements={elements2} renderLink={renderLink} />
+	))
 	.add('BlockImageGrid 150x150 fill contain', () => (
 		<BlockImageGrid
 			elements={elements2}
 			imageWidth={150}
 			imageHeight={150}
 			fill="contain"
-			navigate={navigate}
+			renderLink={renderLink}
 		/>
 	))
 	.add('BlockImageGrid 150x150 fill cover', () => (
@@ -133,7 +160,7 @@ storiesOf('blocks/BlockImageGrid', module)
 			imageWidth={150}
 			imageHeight={150}
 			fill="cover"
-			navigate={navigate}
+			renderLink={renderLink}
 		/>
 	))
 	.add('BlockImageGrid 150x150 fill auto', () => (
@@ -142,18 +169,31 @@ storiesOf('blocks/BlockImageGrid', module)
 			imageWidth={150}
 			imageHeight={150}
 			fill="auto"
-			navigate={navigate}
+			renderLink={renderLink}
 		/>
 	))
 	.add('BlockImageGrid align left', () => (
-		<BlockImageGrid elements={elements2} align="left" navigate={navigate} />
+		<BlockImageGrid elements={elements2} align="left" renderLink={renderLink} />
 	))
 	.add('BlockImageGrid align right', () => (
-		<BlockImageGrid elements={elements2} align="right" navigate={navigate} />
+		<BlockImageGrid elements={elements2} align="right" renderLink={renderLink} />
 	))
 	.add('BlockImageGrid align left align text right', () => (
-		<BlockImageGrid elements={elements2} align="left" textAlign="right" navigate={navigate} />
+		<BlockImageGrid
+			elements={elements2}
+			align="left"
+			textAlign="right"
+			renderLink={renderLink}
+		/>
 	))
 	.add('BlockImageGrid align right align text left', () => (
-		<BlockImageGrid elements={elements2} align="right" textAlign="left" navigate={navigate} />
+		<BlockImageGrid
+			elements={elements2}
+			align="right"
+			textAlign="left"
+			renderLink={renderLink}
+		/>
+	))
+	.add('BlockImageGrid text above logo', () => (
+		<BlockImageGrid elements={elements3} renderLink={renderLink} itemWidth={300} />
 	));

--- a/src/content-blocks/BlockImageGrid/BlockImageGrid.tsx
+++ b/src/content-blocks/BlockImageGrid/BlockImageGrid.tsx
@@ -3,13 +3,16 @@ import { get } from 'lodash-es';
 import React, { FunctionComponent, ReactNode } from 'react';
 
 import { Button, ButtonType, Spacer } from '../../components';
-import { AlignOptions, ButtonAction, DefaultProps } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { AlignOptions, ButtonAction, DefaultProps, RenderLinkFunction } from '../../types';
 
 import './BlockImageGrid.scss';
 
 export interface GridItem {
 	source: string;
+	titleAbove?: string;
 	title?: string;
+	textAbove?: string | ReactNode;
 	text?: string | ReactNode;
 	buttonLabel?: string;
 	buttonType?: ButtonType;
@@ -26,7 +29,7 @@ export interface BlockImageGridProps extends DefaultProps {
 	align?: AlignOptions;
 	textAlign?: AlignOptions;
 	className?: string;
-	navigate?: (action: ButtonAction) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
@@ -38,8 +41,55 @@ export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
 	align = 'center',
 	textAlign = 'center',
 	className,
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => {
+	const renderGridImage = (element: GridItem) => {
+		return (
+			<>
+				{element.textAbove && (
+					<div className="c-block-grid__text-wrapper">
+						<Spacer margin="bottom-small">
+							<p>{element.textAbove}</p>
+						</Spacer>
+					</div>
+				)}
+				<div
+					className="c-block-grid__image"
+					style={{
+						width: `${imageWidth}px`,
+						height: `${imageHeight}px`,
+						backgroundImage: `url(${element.source})`,
+						backgroundSize: fill,
+					}}
+				/>
+				<div className="c-block-grid__text-wrapper">
+					{!!element.title && (
+						<Spacer margin="top-small">
+							<h3>
+								<strong>{element.title}</strong>
+							</h3>
+						</Spacer>
+					)}
+					{!!element.text && (
+						<Spacer margin="top-small">
+							<p>{element.text}</p>
+						</Spacer>
+					)}
+					{!!element.buttonLabel && (
+						<Spacer margin="top-small" className="c-block-grid__button-spacer">
+							<Button
+								label={element.buttonLabel}
+								type={element.buttonType}
+								title={element.buttonTitle}
+								ariaLabel={element.buttonLabel || element.buttonTitle}
+							/>
+						</Spacer>
+					)}
+				</div>
+			</>
+		);
+	};
+
 	return (
 		<div
 			className={classnames(
@@ -49,52 +99,13 @@ export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
 				className
 			)}
 		>
-			{elements.map(element => (
+			{elements.map((element) => (
 				<div
 					key={`block-grid-${get(element, 'action.value')}`}
-					className={classnames('c-block-grid__item', {
-						'u-clickable': !!navigate && !!element.action,
-					})}
+					className={classnames('c-block-grid__item')}
 					style={{ width: `${itemWidth}px` }}
-					onClick={() => {
-						if (element.action && navigate) {
-							navigate(element.action);
-						}
-					}}
 				>
-					<div
-						className="c-block-grid__image"
-						style={{
-							width: `${imageWidth}px`,
-							height: `${imageHeight}px`,
-							backgroundImage: `url(${element.source})`,
-							backgroundSize: fill,
-						}}
-					/>
-					<div className="c-block-grid__text-wrapper">
-						{!!element.title && (
-							<Spacer margin="top-small">
-								<h3>
-									<strong>{element.title}</strong>
-								</h3>
-							</Spacer>
-						)}
-						{!!element.text && (
-							<Spacer margin="top-small">
-								<p>{element.text}</p>
-							</Spacer>
-						)}
-						{!!element.buttonLabel && (
-							<Spacer margin="top-small" className="c-block-grid__button-spacer">
-								<Button
-									label={element.buttonLabel}
-									type={element.buttonType}
-									title={element.buttonTitle}
-									ariaLabel={element.buttonLabel || element.buttonTitle}
-								/>
-							</Spacer>
-						)}
-					</div>
+					{renderLink(element.action, renderGridImage(element))}
 				</div>
 			))}
 		</div>

--- a/src/content-blocks/BlockMediaGrid/BlockMediaGrid.mock.ts
+++ b/src/content-blocks/BlockMediaGrid/BlockMediaGrid.mock.ts
@@ -1,5 +1,6 @@
 import { ButtonTypeSchema } from '../../components/Button/Button.types';
 import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 
 import { BlockMediaGridProps, MediaListItem } from './BlockMediaGrid';
 
@@ -139,13 +140,13 @@ export const MEDIA_LIST_ITEMS_MOCK: MediaListItem[] = [
 export const MEDIA_LIST_MOCK: BlockMediaGridProps = {
 	title: 'Collecties secundair onderwijs',
 	elements: MEDIA_LIST_ITEMS_MOCK,
-	navigate: action('navigate to: '),
+	renderLink: testRenderLink(action('navigate to: ')),
 };
 
 export const MEDIA_LIST_TITLE_MOCK: BlockMediaGridProps = {
 	title: 'Collecties secundair onderwijs',
 	elements: MEDIA_LIST_ITEMS_MOCK,
-	navigate: action('navigate to: '),
+	renderLink: testRenderLink(action('navigate to')),
 };
 
 export const MEDIA_LIST_TITLE_BUTTON_MOCK: BlockMediaGridProps = {
@@ -167,7 +168,7 @@ export const MEDIA_LIST_CTA_MOCK: BlockMediaGridProps = {
 		type: 'EXTERNAL_LINK',
 		value: 'http://google.com',
 	},
-	navigate: action('navigate to: '),
+	renderLink: testRenderLink(action('navigate to')),
 };
 
 export const MEDIA_LIST_CTA_MOCK_WITHOUT_BUTTONS: BlockMediaGridProps = {
@@ -175,7 +176,7 @@ export const MEDIA_LIST_CTA_MOCK_WITHOUT_BUTTONS: BlockMediaGridProps = {
 	ctaContent: 'Wil je meer weten?',
 	ctaButtonLabel: 'Ontdek meer',
 	ctaButtonIcon: 'delete',
-	elements: MEDIA_LIST_ITEMS_MOCK.slice(0, -1).map(mock => {
+	elements: MEDIA_LIST_ITEMS_MOCK.slice(0, -1).map((mock) => {
 		const { buttonLabel, buttonIcon, buttonType, ...rest } = mock;
 		return rest;
 	}),
@@ -183,7 +184,7 @@ export const MEDIA_LIST_CTA_MOCK_WITHOUT_BUTTONS: BlockMediaGridProps = {
 		type: 'EXTERNAL_LINK',
 		value: 'http://google.com',
 	},
-	navigate: action('navigate to: '),
+	renderLink: testRenderLink(action('navigate to')),
 };
 
 export const MEDIA_LIST_COLORED_CTA_MOCK: BlockMediaGridProps = {

--- a/src/content-blocks/BlockMediaGrid/BlockMediaGrid.stories.tsx
+++ b/src/content-blocks/BlockMediaGrid/BlockMediaGrid.stories.tsx
@@ -3,6 +3,8 @@ import { get } from 'lodash-es';
 import React from 'react';
 
 import { FlowPlayer } from '../../components';
+import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 
 import { BlockMediaGrid } from './BlockMediaGrid';
 import {
@@ -30,6 +32,7 @@ storiesOf('blocks/BlockMediaGrid', module)
 			renderPlayerModalBody={(item) => (
 				<FlowPlayer src={item.src as string} poster={get(item, 'thumbnail.src')} />
 			)}
+			renderLink={testRenderLink(action('BlockMediaGrid with modal player'))}
 		/>
 	))
 	.add('BlockMediaGrid with CTA', () => <BlockMediaGrid {...MEDIA_LIST_CTA_MOCK} />)

--- a/src/content-blocks/BlockMediaGrid/BlockMediaGrid.test.tsx
+++ b/src/content-blocks/BlockMediaGrid/BlockMediaGrid.test.tsx
@@ -28,9 +28,7 @@ describe('<BlockMediaGrid />', () => {
 	});
 
 	it('Should correctly render a CTA when given', () => {
-		const blockMediaGrid = mount(
-			<BlockMediaGrid navigate={() => {}} {...MEDIA_LIST_CTA_MOCK} />
-		);
+		const blockMediaGrid = mount(<BlockMediaGrid {...MEDIA_LIST_CTA_MOCK} />);
 
 		const ctaItem = blockMediaGrid.find('.c-cta-item');
 		const ctaButtonLabel = ctaItem.find('.c-cta__content .c-button__label');

--- a/src/content-blocks/BlockPageOverview/BlockPageOverview.stories.tsx
+++ b/src/content-blocks/BlockPageOverview/BlockPageOverview.stories.tsx
@@ -3,6 +3,7 @@ import { intersectionBy, times } from 'lodash-es';
 import React, { cloneElement, ReactElement, useEffect, useState } from 'react';
 
 import { action } from '../../helpers';
+import { testRenderLink } from "../../helpers/render-link";
 
 import { BlockPageOverview, LabelObj, PageInfo } from './BlockPageOverview';
 import { CONTENT_PAGES_MOCK } from './BlockPageOverview.mock';
@@ -76,7 +77,7 @@ const baseProps = {
 	selectedTabs: [],
 	itemStyle: 'NEWS_LIST' as any,
 	tabStyle: 'MENU_BAR' as any,
-	navigate: action('navigate'),
+	renderLink: testRenderLink(action('navigate')),
 };
 
 storiesOf('blocks/BlockPageOverview', module)

--- a/src/content-blocks/BlockPageOverview/BlockPageOverview.tsx
+++ b/src/content-blocks/BlockPageOverview/BlockPageOverview.tsx
@@ -17,7 +17,8 @@ import {
 	TagList,
 } from '../../components';
 import { convertToHtml } from '../../helpers';
-import { ButtonAction, DefaultProps } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { ButtonAction, DefaultProps, RenderLinkFunction } from '../../types';
 import { BlockHeading } from '../BlockHeading/BlockHeading';
 import { BlockImageGrid, GridItem } from '../BlockImageGrid/BlockImageGrid';
 
@@ -70,7 +71,7 @@ export interface BlockPageOverviewProps extends DefaultProps {
 	pages: PageInfo[];
 	activePageId?: number; // Used to expand the active accordion
 	onLabelClicked?: (label: string) => void;
-	navigate?: (action: ButtonAction) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
@@ -95,7 +96,7 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 	pages = [],
 	activePageId,
 	onLabelClicked,
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => {
 	const allLabelObj = { label: allLabel, id: -2 };
 	const noLabelObj = { label: noLabel, id: -2 };
@@ -127,15 +128,6 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 
 		// Empty selected tabs signifies to the outsides: show all items / do not apply any label filters
 		onSelectedTabsChanged(newSelectedTabs.filter((tab) => tab.id !== allLabelObj.id));
-	};
-
-	const handlePageClick = (page: PageInfo) => {
-		if (navigate) {
-			navigate({
-				type: 'CONTENT_PAGE',
-				value: page.path,
-			} as ButtonAction);
-		}
 	};
 
 	const renderLabel = (labelObj: any) => {
@@ -218,15 +210,17 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 								<Column size="2-7">
 									<div className="c-content">
 										{showTitle &&
-											(itemStyle === 'NEWS_LIST' ? (
-												<h3 onClick={() => handlePageClick(page)}>
-													{page.title}
-												</h3>
-											) : (
-												<h2 onClick={() => handlePageClick(page)}>
-													{page.title}
-												</h2>
-											))}
+											renderLink(
+												{
+													type: 'CONTENT_PAGE',
+													value: page.path,
+												} as ButtonAction,
+												itemStyle === 'NEWS_LIST' ? (
+													<h3>{page.title}</h3>
+												) : (
+													<h2>{page.title}</h2>
+												)
+											)}
 										{showDate && (
 											<div onClick={handleLabelClicked}>
 												{renderText(
@@ -242,11 +236,13 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 										}
 										{buttonLabel && (
 											<Spacer margin="top">
-												<Button
-													label={buttonLabel}
-													type="tertiary"
-													onClick={() => handlePageClick(page)}
-												/>
+												{renderLink(
+													{
+														type: 'CONTENT_PAGE',
+														value: page.path,
+													} as ButtonAction,
+													<Button label={buttonLabel} type="tertiary" />
+												)}
 											</Spacer>
 										)}
 									</div>
@@ -302,7 +298,7 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 							itemWidth={307}
 							imageHeight={172}
 							imageWidth={307}
-							navigate={navigate}
+							renderLink={renderLink}
 							fill="cover"
 							textAlign="left"
 						/>

--- a/src/content-blocks/BlockRichText/BlockRichText.tsx
+++ b/src/content-blocks/BlockRichText/BlockRichText.tsx
@@ -6,7 +6,8 @@ import { Column, GridSizeSchema } from '../../components/Grid/Column/Column';
 import { Grid } from '../../components/Grid/Grid';
 import { Spacer } from '../../components/Spacer/Spacer';
 import { convertToHtml } from '../../helpers';
-import { ButtonAction, DefaultProps } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { ButtonAction, DefaultProps, RenderLinkFunction } from '../../types';
 
 import './BlockRichText.scss';
 
@@ -19,7 +20,7 @@ interface BlockRichTextElement {
 export interface BlockRichTextProps extends DefaultProps {
 	elements: BlockRichTextElement | BlockRichTextElement[];
 	maxTextWidth?: string;
-	navigate?: (buttonAction: any) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const BlockRichText: FunctionComponent<BlockRichTextProps> = ({
@@ -30,15 +31,12 @@ export const BlockRichText: FunctionComponent<BlockRichTextProps> = ({
 		},
 	],
 	maxTextWidth,
-	navigate,
+	renderLink = defaultRenderLinkFunction,
 }) => {
 	const renderButtons = (columnIndex: number, buttons: any[]) =>
 		buttons.map((buttonProps: any, buttonIndex: number) => (
 			<Spacer key={`rich-text-column-${columnIndex}-button-${buttonIndex}`} margin="top">
-				<Button
-					{...buttonProps}
-					onClick={navigate ? () => navigate(buttonProps.buttonAction) : () => null}
-				/>
+				{renderLink(buttonProps.buttonAction, <Button {...buttonProps} />)}
 			</Spacer>
 		));
 

--- a/src/content-blocks/BlockSpotlight/BlockSpotlight.scss
+++ b/src/content-blocks/BlockSpotlight/BlockSpotlight.scss
@@ -22,6 +22,11 @@
 	background-repeat: no-repeat;
 	height: 200px;
 
+	> * {
+		width: 100%;
+		height: 100%;
+	}
+
 	p {
 		position: absolute;
 		left: 0;

--- a/src/content-blocks/BlockSpotlight/BlockSpotlight.stories.tsx
+++ b/src/content-blocks/BlockSpotlight/BlockSpotlight.stories.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 
 import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 
 import { BlockSpotlight } from './BlockSpotlight';
 import { MOCK_SPOTLIGHT_PROJECTS } from './BlockSpotlight.mock';
@@ -11,6 +12,6 @@ storiesOf('blocks/BlockSpotlight', module)
 	.add('BlockSpotlight', () => (
 		<BlockSpotlight
 			elements={MOCK_SPOTLIGHT_PROJECTS}
-			navigate={action('Clicked on spotlight item')}
+			renderLink={testRenderLink(action('Clicked on spotlight item'))}
 		/>
 	));

--- a/src/content-blocks/BlockSpotlight/BlockSpotlight.test.tsx
+++ b/src/content-blocks/BlockSpotlight/BlockSpotlight.test.tsx
@@ -2,6 +2,7 @@ import { mount, shallow } from 'enzyme';
 import React from 'react';
 
 import { action } from '../../helpers';
+import { testRenderLink } from '../../helpers/render-link';
 
 import { BlockSpotlight } from './BlockSpotlight';
 import { MOCK_SPOTLIGHT_PROJECTS } from './BlockSpotlight.mock';
@@ -9,7 +10,7 @@ import { MOCK_SPOTLIGHT_PROJECTS } from './BlockSpotlight.mock';
 const BlockSpotlightExample = (
 	<BlockSpotlight
 		elements={MOCK_SPOTLIGHT_PROJECTS}
-		navigate={action('Clicked on spotlight item')}
+		renderLink={testRenderLink(action('Clicked on spotlight item'))}
 	/>
 );
 

--- a/src/content-blocks/BlockSpotlight/BlockSpotlight.tsx
+++ b/src/content-blocks/BlockSpotlight/BlockSpotlight.tsx
@@ -2,7 +2,8 @@ import classnames from 'classnames';
 import { get } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
 
-import { ButtonAction, DefaultProps } from '../../types';
+import { defaultRenderLinkFunction } from '../../helpers/render-link';
+import { ButtonAction, DefaultProps, RenderLinkFunction } from '../../types';
 
 import './BlockSpotlight.scss';
 
@@ -15,12 +16,12 @@ export interface ImageInfo {
 
 export interface BlockSpotlightProps extends DefaultProps {
 	elements: ImageInfo[];
-	navigate: (buttonAction: ButtonAction) => void;
+	renderLink?: RenderLinkFunction;
 }
 
 export const BlockSpotlight: FunctionComponent<BlockSpotlightProps> = ({
 	elements,
-	navigate = () => {},
+	renderLink = defaultRenderLinkFunction,
 	className,
 }) => {
 	function renderItem(index: number) {
@@ -28,16 +29,14 @@ export const BlockSpotlight: FunctionComponent<BlockSpotlightProps> = ({
 			return null;
 		}
 		const buttonAction = get(elements, [index, 'buttonAction']);
-		const navigateOnClick: Function = buttonAction ? () => navigate(buttonAction) : () => {};
 		return (
 			<div
 				className={classnames('c-spotlight__item', {
 					'u-clickable': !!buttonAction,
 				})}
 				style={{ backgroundImage: `url(${get(elements, [index, 'image'])})` }}
-				onClick={() => navigateOnClick()}
 			>
-				<p>{get(elements, [index, 'title'])}</p>
+				{renderLink(buttonAction, <p>{get(elements, [index, 'title'])}</p>)}
 			</div>
 		);
 	}

--- a/src/helpers/render-link.tsx
+++ b/src/helpers/render-link.tsx
@@ -4,17 +4,21 @@ import { ButtonAction, RenderLinkFunction } from '../types';
 
 export function testRenderLink(testActionHandler: (info: any) => void): RenderLinkFunction {
 	return (buttonAction: ButtonAction | undefined | null, children: ReactNode) => {
-		return (
-			<div
-				onClick={() => {
-					if (buttonAction) {
-						testActionHandler(buttonAction);
-					}
-				}}
-			>
-				{children}
-			</div>
-		);
+		if (buttonAction) {
+			return (
+				<a
+					href={buttonAction.value.toString()}
+					onClick={() => {
+						if (buttonAction) {
+							testActionHandler(buttonAction);
+						}
+					}}
+				>
+					{children}
+				</a>
+			);
+		}
+		return <>{children}</>;
 	};
 }
 

--- a/src/helpers/render-link.tsx
+++ b/src/helpers/render-link.tsx
@@ -1,0 +1,27 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+import { ButtonAction, RenderLinkFunction } from '../types';
+
+export function testRenderLink(testActionHandler: (info: any) => void): RenderLinkFunction {
+	return (buttonAction: ButtonAction | undefined | null, children: ReactNode) => {
+		return (
+			<div
+				onClick={() => {
+					if (buttonAction) {
+						testActionHandler(buttonAction);
+					}
+				}}
+			>
+				{children}
+			</div>
+		);
+	};
+}
+
+export function defaultRenderLinkFunction(
+	// @ts-ignore
+	buttonAction: ButtonAction | undefined | null,
+	children: ReactNode
+): ReactElement<any, any> | null {
+	return <>{children}</>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, ReactElement, ReactNode } from 'react';
 
 export * from './content-type';
 
@@ -38,3 +38,8 @@ export interface ButtonAction {
 }
 
 export type Orientation = 'horizontal' | 'vertical';
+
+export type RenderLinkFunction = (
+	buttonAction: ButtonAction | null | undefined,
+	children: ReactNode
+) => ReactElement<any, any> | null;


### PR DESCRIPTION
partially closes: https://meemoo.atlassian.net/browse/AVO-1043

twin client PR: https://github.com/viaacode/avo2-client/pull/1084

so we can open links in new tab by right clicking the link/button

![image](https://user-images.githubusercontent.com/1710840/97013296-2e637d00-1549-11eb-986d-c4c10a500ab8.png)
