### PR TITLE
fix(flowplayer): avoid re-init when token of video changes

### DIFF
--- a/src/components/FlowPlayer/FlowPlayer.tsx
+++ b/src/components/FlowPlayer/FlowPlayer.tsx
@@ -122,8 +122,10 @@ export class FlowPlayer extends React.Component<FlowPlayerPropsSchema, FlowPlaye
 			return true;
 		}
 
-		if (nextProps.src !== this.props.src) {
-			if (nextProps.src) {
+		const nextUrl: string | undefined = nextProps.src && nextProps.src.split('?')[0];
+		const currentUrl: string | undefined = this.props.src && this.props.src.split('?')[0];
+		if (nextUrl !== currentUrl) {
+			if (nextUrl) {
 				// User clicked the post to play the video
 				this.reInitFlowPlayer(nextProps);
 			} else {


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1416

avoid re-init flowplayer when url updates because the play ticket changed

|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/98004693-84111280-1df0-11eb-9d56-02eece7dced5.png)|![image](https://user-images.githubusercontent.com/1710840/98004680-81aeb880-1df0-11eb-9bc0-3a8d387d2ff3.png)|