### PR TITLE
fix(grid): make columns 100% wide on mobile

### DIFF
--- a/src/components/Grid/Grid.scss
+++ b/src/components/Grid/Grid.scss
@@ -26,6 +26,7 @@ $o-grid-column-gap: 2.4rem !default;
 
 [class*='o-grid-col'] {
 	min-width: 0;
+	width: 100%;
 	margin-left: $o-grid-column-gap / 2;
 	margin-right: $o-grid-column-gap / 2;
 }
@@ -34,7 +35,7 @@ $o-grid-column-gap: 2.4rem !default;
 $i: 0;
 
 @while($i < $o-grid-columns) {
-	.o-grid-col-#{$i + 1} {
+	.o-grid-col-#{$i + 1}{
 		width: calc(#{( ( $i + 1 ) / $o-grid-columns ) * 100}% - #{$o-grid-column-gap});
 		flex: 1 1 auto;
 	}


### PR DESCRIPTION
|before|after|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/1710840/98024099-212b7580-1e08-11eb-9fc3-dde6f69db63f.png)|![image](https://user-images.githubusercontent.com/1710840/98024104-22f53900-1e08-11eb-92e3-558b5a1b745c.png)|