### PR TITLE
fix(menu): disable hidden menu mouse interactions

### DIFF
--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -26,12 +26,14 @@ $g-c-menu-z: 60 !default;
 	padding: 0.4rem 0;
 	position: absolute;
 	visibility: hidden;
+	pointer-events: none;
 	z-index: $g-c-menu-z;
 }
 
 .c-menu--visible {
 	opacity: 1;
 	visibility: visible;
+	pointer-events: auto;
 }
 
 .c-menu--search-result {


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-1232

content from a dropdown menu could still occlude the mouse since it was only set to visible: hidden, but no pointer-events: none:
![image](https://user-images.githubusercontent.com/1710840/98412679-a87f2000-2078-11eb-8f62-76296425ccbe.png)
