### PR TITLE
fix(block-image-grid): fix usp grid text size and color

### DIFF
--- a/src/components/ImageGrid/ImageGrid.scss
+++ b/src/components/ImageGrid/ImageGrid.scss
@@ -5,6 +5,10 @@
 	flex-wrap: wrap;
 	justify-content: center;
 
+	h3 {
+		font-size: 20px;
+	}
+
 	img {
 		display: block;
 	}

--- a/src/content-blocks/BlockImageGrid/BlockImageGrid.tsx
+++ b/src/content-blocks/BlockImageGrid/BlockImageGrid.tsx
@@ -31,6 +31,7 @@ export interface BlockImageGridProps extends DefaultProps {
 	textSize?: number;
 	textMargin?: number;
 	textWeight?: number;
+	textColor?: string;
 	className?: string;
 	horizontalMargin?: number;
 	verticalMargin?: number;
@@ -48,6 +49,7 @@ export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
 	textSize = 15,
 	textMargin = 0,
 	textWeight = 500,
+	textColor = '#2B414F',
 	horizontalMargin = 10,
 	verticalMargin = 10,
 	className,
@@ -72,7 +74,12 @@ export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
 						backgroundSize: fill,
 					}}
 				/>
-				<div className="c-block-grid__text-wrapper">
+				<div
+					className="c-block-grid__text-wrapper"
+					style={{
+						color: textColor,
+					}}
+				>
 					{!!element.title && (
 						<Spacer margin="top-small">
 							<h3


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-732

fix color and size of text in block-image-grid
![image](https://user-images.githubusercontent.com/1710840/101044219-649c0f80-357f-11eb-9a5c-13a43baa15d5.png)
