### PR TITLE
fix(date-picker): avoid parsing date with wrong format as USA format

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -28,11 +28,13 @@ storiesOf('components/DatePicker', module)
 	.addParameters({ jest: ['DatePicker'] })
 	.add('DatePicker', () => (
 		<Fragment>
-			<Spacer margin="bottom">
-				<DatePickerStoryComponent>
-					<DatePicker onChange={action('onChange')} />
-				</DatePickerStoryComponent>
-			</Spacer>
+			<DatePickerStoryComponent>
+				<DatePicker onChange={action('onChange')} />
+			</DatePickerStoryComponent>
+		</Fragment>
+	))
+	.add('DatePicker disabled', () => (
+		<Fragment>
 			<DatePickerStoryComponent>
 				<DatePicker disabled />
 			</DatePickerStoryComponent>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { setHours, setMinutes } from 'date-fns';
+import { isValid, parse, setHours, setMinutes } from 'date-fns';
 // https://github.com/Hacker0x01/react-datepicker/issues/1815#issuecomment-513215416
 import nl from 'date-fns/locale/nl';
 import React, { FunctionComponent } from 'react';
@@ -47,6 +47,14 @@ export const DatePicker: FunctionComponent<DatePickerPropsSchema> = ({
 				timeCaption="tijd"
 				showTimeSelect={showTimeInput}
 				injectTimes={[setHours(setMinutes(new Date(), 59), 23)]}
+				strictParsing
+				onChangeRaw={(event) => {
+					const rawInput = (event.target.value || '').trim().replace(/[^0-9]+/g, '/');
+					const newDate = parse(rawInput, 'dd/MM/yyyy', new Date(), { locale: nl });
+					if (isValid(newDate)) {
+						onChange(newDate);
+					}
+				}}
 			/>
 			<Icon name="calendar" />
 		</div>


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1475

before: dates with "-" instead of "/" would be parsed as usa date format:
![image](https://user-images.githubusercontent.com/1710840/126194334-87ad78e2-743d-4303-8ccd-c15916cae28b.png)

after: You can enter a date format with dashes:
![image](https://user-images.githubusercontent.com/1710840/126194367-921e6459-c40a-43e2-a1af-4d85ce856e31.png)

when you press enter the date is parsed and the format is converted to "/"
![image](https://user-images.githubusercontent.com/1710840/126194459-c4222ff7-3522-4b72-a205-2df223f04c14.png)

when you click inside the input field again, the correct date is shown:
![image](https://user-images.githubusercontent.com/1710840/126194501-16a68577-955b-4ef5-9c6f-ec42e4207fc2.png)

