### PR TITLE
fix(avo-1927): add margin to label next to icon inside dropdown trigger

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -2,6 +2,8 @@
    Component: Dropdown
    ========================================================================== */
 
+$c-button-icon-spacing-small: 0.2rem !default;
+
 .c-dropdown__trigger {
 	display: inline-block;
 

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -4,6 +4,10 @@
 
 .c-dropdown__trigger {
 	display: inline-block;
+
+	.o-svg-icon + .c-button__label {
+		margin-left: $c-button-icon-spacing-small;
+	}
 }
 
 .c-dropdown__menu {


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1710840/176154096-d92314f5-bf19-48f2-915d-1244ca822de1.png)

after:
![image](https://user-images.githubusercontent.com/1710840/176154117-66243573-e4cb-4b95-be55-7d7f6ab0fde0.png)
