### PR TITLE
feat(avo-1929): fix vertical center

### DIFF
--- a/src/components/Flex/Flex.scss
+++ b/src/components/Flex/Flex.scss
@@ -21,7 +21,8 @@ $o-flex-gutter-width: 0.8rem !default;
 }
 
 .o-flex--vertical-center {
-	align-items: center;
+	flex-direction: column;
+	justify-content: center;
 }
 
 .o-flex--horizontal-center {

--- a/src/components/WYSIWYG/WYSIWYG.tsx
+++ b/src/components/WYSIWYG/WYSIWYG.tsx
@@ -1,8 +1,5 @@
 import React, { FunctionComponent, Suspense } from 'react';
 
-import { Flex } from '../Flex/Flex';
-import { Spinner } from '../Spinner/Spinner';
-
 import { WYSIWYGPropsSchema } from './WYSIWYG.types';
 
 const WYSIWYGInternal = React.lazy(() => import('./WYSIWYGInternal'));
@@ -10,11 +7,7 @@ const WYSIWYGInternal = React.lazy(() => import('./WYSIWYGInternal'));
 export const WYSIWYG: FunctionComponent<WYSIWYGPropsSchema> = (props) => {
 	return (
 		<Suspense
-			fallback={
-				<Flex orientation="horizontal" center>
-					<Spinner size="large" />
-				</Flex>
-			}
+			fallback={<span>loading</span>} // TODO Used components are not included in main build and not loaded
 		>
 			<WYSIWYGInternal {...props} />
 		</Suspense>


### PR DESCRIPTION
avoid separate flex file on build since wysiwyg is built separately and depended on flex

Nog niet zeker of dit de oplossing is want krijg de wijzigingen maar niet te zien in avo2-client