### PR TITLE
fix(avo-2142): fix time input field styling on firefox

### DIFF
--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -34,6 +34,7 @@
 			border-left: 0;
 			border-radius: 0 4px 4px 0;
 			min-width: 7rem;
+			white-space: initial;
 		}
 	}
 }


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2142

before:
![image](https://user-images.githubusercontent.com/1710840/187703199-08d8fffd-18fe-4702-90f7-dfe9d8ec0210.png)


after:
![image](https://user-images.githubusercontent.com/1710840/187703216-1e595140-f945-4f12-a9d8-000169360c0f.png)
